### PR TITLE
Deploy backend with `.env`

### DIFF
--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 
 env = os.path.join(os.getcwd(), '.env')
 if os.path.exists(env):

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,0 +1,5 @@
+import os
+
+env = os.path.join(os.getcwd(), '.env')
+if os.path.exists(env):
+    load_dotenv(env)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ Flask==1.1.2
 Flask-Cors==3.0.9
 Flask-SQLAlchemy==2.4.4
 GeoAlchemy2==0.8.4
+gunicorn==20.1.0
 iniconfig==1.1.1
 itsdangerous==1.1.0
 Jinja2==2.11.2

--- a/running-the-app.md
+++ b/running-the-app.md
@@ -2,6 +2,24 @@
 
 The steps to set up the app will depend on whether you're (re)starting our production build or working on your own development environment. 
 
+In either case though you'll need to create/modify `/backend/.env` to look something like
+
+```bash
+DB_HOST='10.160.8.132'
+DB_NAME='bigdata'
+DB_USER='tt_request_bot'
+DB_USER_PASSWORD='wouldntyouliketoknow'
+
+SECRET_KEY='yaddayaddayadda'
+DATABASE_URL="postgresql+pg8000://${DB_USER}:${DB_USER_PASSWORD}@${DB_HOST}:5432/${DB_NAME}"
+LINK_TABLE_NAME='routing_streets_name'
+NODE_TABLE_NAME='routing_nodes_intersec_name'
+TRAVEL_DATA_TABLE_NAME='ta'
+TEMP_FILE_LOCATION='tmp'
+KEEP_TEMP_FILE='true'
+POSTGIS_GEOM_SRID=4326
+```
+
 ## Production
 The app is available to users inside the City network at [https://10.160.2.198/traveltime-request/](https://10.160.2.198/traveltime-request/) 
 

--- a/running-the-app.md
+++ b/running-the-app.md
@@ -46,19 +46,7 @@ sudo nginx -s reload
 
 6. ~~Create a pgadmin bot (`tt_request_bot`) to handle here travel time requests and give usage access to this bot for the schemas `here` and `here_gis`, also change the path of this user to schema `here`, and `public`.~~
 
-7. Edit environment variables in `.env` file but that didnt work so export all environment with e.g.
-
-```bash
-export SECRET_KEY='redacted'
-export DATABASE_URL='redacted'
-export LINK_TABLE_NAME=routing_streets_name
-export NODE_TABLE_NAME=routing_nodes_intersec_name
-export TRAVEL_DATA_TABLE_NAME=ta
-export POSTGIS_GEOM_SRID=4326
-export TEMP_FILE_LOCATION='tmp'
-export KEEP_TEMP_FILE='true'
-export DB_DATA_START_DATE='2019-01-01 00:00'
-```
+7. If necessary, edit the environment variables in `backend/.env`
 
 8. Gunicorn is the service to be used to deploy a production version of the API server. Run `GUNICORN_CMD_ARGS="--bind=0.0.0.0:8070  --timeout 90 --name=data_request_app" gunicorn app:app -D`
 

--- a/running-the-app.md
+++ b/running-the-app.md
@@ -38,7 +38,7 @@ sudo nginx -s reload
 
 1. From the project root directory, `cd` into folder `backend`.
 
-2. Execute command `python3 -m venv venv/` to create a python virtual environment for the backend.
+2. ~~Execute command `python3 -m venv venv/` to create a python virtual environment for the backend.~~
 
 3. Execute command `source venv/bin/activate` to use the virtual environment as the python interpreter for the backend.
 

--- a/running-the-app.md
+++ b/running-the-app.md
@@ -44,8 +44,6 @@ sudo nginx -s reload
 
 4. Execute command `pip3 install -r requirements.txt` to install the project dependencies listed in requirements.txt.
 
-5. Execute command `pip3 install gunicorn`. Gunicorn is the service to be used to deploy a production version of the API server.
-
 6. ~~Create a pgadmin bot (`tt_request_bot`) to handle here travel time requests and give usage access to this bot for the schemas `here` and `here_gis`, also change the path of this user to schema `here`, and `public`.~~
 
 7. Edit environment variables in `.env` file but that didnt work so export all environment with e.g.
@@ -62,7 +60,7 @@ export KEEP_TEMP_FILE='true'
 export DB_DATA_START_DATE='2019-01-01 00:00'
 ```
 
-8. Run `GUNICORN_CMD_ARGS="--bind=0.0.0.0:8070  --timeout 90 --name=data_request_app" gunicorn app:app -D`
+8. Gunicorn is the service to be used to deploy a production version of the API server. Run `GUNICORN_CMD_ARGS="--bind=0.0.0.0:8070  --timeout 90 --name=data_request_app" gunicorn app:app -D`
 
 ### Front-end
 


### PR DESCRIPTION
@chmnata FYI, I got this working without the need to export all the environment variables. It now reads them directly from `.env`.