### PR TITLE
get_links: SQL moved Inline and parser eliminated

### DIFF
--- a/backend/app/parse_util.py
+++ b/backend/app/parse_util.py
@@ -6,7 +6,7 @@ from flask import abort
 from app import ALLOWED_FILE_TYPES, TIME_FORMAT, DATE_FORMAT, DB_TRAVEL_DATA_QUERY_RESULT_FORMAT
 
 __all__ = ['parse_file_type_request_body', 'parse_travel_request_body', 'parse_link_response', 'parse_travel_data_query_result',
-           'parse_get_links_between_multi_nodes_request_body', 'get_path_list_from_link_list']
+           'get_path_list_from_link_list']
 
 
 def parse_file_type_request_body(file_request_data):
@@ -55,42 +55,6 @@ def parse_file_type_request_body(file_request_data):
         columns = list(DB_TRAVEL_DATA_QUERY_RESULT_FORMAT)
 
     return file_type, columns
-
-
-def parse_get_links_between_multi_nodes_request_body(nodes_data):
-    """
-    Parse the request body that contains a list of node_ids.
-    This function will call abort with response code 400 and error messages if any of the node_id is not an integer, or
-    if field 'node_ids' does not exist in the request body, or if field 'node_ids' is not a list with minimum length 2.
-
-    :param nodes_data: the body of the get_links_between_multi_nodes request
-    :return: a list of integer node ids
-    """
-    try:
-        if 'node_ids' not in nodes_data:
-            abort(400, description="Must provide a list of node_ids")
-            return
-    except TypeError:
-        abort(400,
-              description="Request body of get_links_between_multi_nodes must be a JSON containing field 'node_ids'")
-        return
-
-    node_id_list = nodes_data['node_ids']
-    if type(node_id_list) != list or len(node_id_list) < 2:
-        abort(400, description="Field 'node_ids' must be a list of at least 2 node ids.")
-        return
-
-    node_ids = []
-    for node_id in node_id_list:
-        try:
-            node_id_int = int(node_id)
-        except ArithmeticError:
-            abort(400, description='node_id must be an integer.')
-            return
-
-        node_ids.append(node_id_int)
-
-    return node_ids
 
 
 def parse_travel_data_query_result(travel_query_result, columns, street_info):

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -158,13 +158,14 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
                 inner join here.routing_streets_name on edge = id'''
             cursor.execute(select_sql, {"node_start": from_node_id, "node_end": to_node_id})
             source, target, path, link_dirs, geometry = cursor.fetchall()[0]
+            print(type(geometry))
 
         # parsing query result
         # shortest_link_data = parse_get_links_btwn_nodes_response(str(shortest_link_query_result))
 
 
     shortest_link_data = {"source": source, "target": target,
-        "path_name": path, "link_dirs": link_dirs, "geometry": geometry}
+        "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
 
     connection.close()
     
@@ -224,7 +225,7 @@ def get_links_between_multi_nodes():
 
 
         shortest_link_data = {"source": source, "target": target,
-            "path_name": path, "link_dirs": link_dirs, "geometry": geometry}
+            "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
         optimal_links_data_list.append(shortest_link_data)
 
     connection.close()

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -111,20 +111,7 @@ def get_closest_node(longitude, latitude):
 
 @app.route('/link-nodes/<from_node_id>/<to_node_id>', methods=['GET'])
 def get_links_between_two_nodes(from_node_id, to_node_id):
-    """
-    Get the shortest length link between the two given nodes.
-    This function filters links using ST_Intersects and sort them using the
-    length attribute of the link object.
-    This function will call abort with response code 400 when the given node_ids
-    can not be cast to an integer, the two nodes given are the same or no link exists between the two nodes.
-
-    :param from_node_id: source node id
-    :param to_node_id: target node id
-    :return: JSON representing a link object, which is the shortest link between
-            the two points. Link object keys: link_dir(str), link_id(int), st_name(str),
-            source(int), target(int), length(float),
-            geometry(geom{type(str), coordinates(list[int])})
-    """
+    """Returns the shortest path between two nodes."""
     try:
         from_node_id = int(from_node_id)
         to_node_id = int(to_node_id)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -136,9 +136,6 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
         abort(400, description="Source node can not be the same as target node.")
         return
 
-
-    # shortest_link_query_result = db.session.query(func.get_links_btwn_nodes(from_node_id, to_node_id)).first()[0]
-
     connection = getConnection()
 
     with connection:
@@ -159,10 +156,6 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
             cursor.execute(select_sql, {"node_start": from_node_id, "node_end": to_node_id})
             source, target, path, link_dirs, geometry = cursor.fetchall()[0]
             print(type(geometry))
-
-        # parsing query result
-        # shortest_link_data = parse_get_links_btwn_nodes_response(str(shortest_link_query_result))
-
 
     shortest_link_data = {"source": source, "target": target,
         "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
@@ -199,8 +192,6 @@ def get_links_between_multi_nodes():
         if curr_node_id == next_node_id:
             continue
 
-        # shortest_link_query_result = db.session.query(func.get_links_btwn_nodes(curr_node_id, next_node_id)).first()[0]
-
 
         with connection:
             with connection.cursor() as cursor:
@@ -219,9 +210,6 @@ def get_links_between_multi_nodes():
                     inner join here.routing_streets_name on edge = id'''
                 cursor.execute(select_sql, {"node_start": curr_node_id, "node_end": next_node_id})
                 source, target, path, link_dirs, geometry = cursor.fetchall()[0] 
-
-        # parsing query result
-        # shortest_link_data = parse_get_links_btwn_nodes_response(str(shortest_link_query_result))
 
 
         shortest_link_data = {"source": source, "target": target,

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -172,61 +172,6 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
     return jsonify(shortest_link_data)
 
 
-# @app.route('/link-nodes', methods=['POST'])
-# def get_links_between_multi_nodes():
-#     """
-#     Get the shortest length link connecting the given nodes in order.
-#     This function filters links using ST_Intersects and sort them using the
-#     length attribute of the link object.
-#     If any two consecutive nodes in the list are the same, they are skipped.
-#     This function will call abort with response code 400 when the given node_ids can not be cast to an integer
-#     or no link exists between the two nodes.
-
-#     :return: JSON representing an array of link objects, which are the shortest links connecting given points.
-#             Link object keys: link_dir(str), link_id(int), st_name(str),
-#             source(int), target(int), length(float),
-#             geometry(geom{type(str), coordinates(list[int])})
-#     """
-#     node_ids = parse_get_links_between_multi_nodes_request_body(request.json)
-#     optimal_links_data_list = []
-
-#     connection = getConnection()
-
-#     for i in range(len(node_ids) - 1):
-#         curr_node_id = node_ids[i]
-#         next_node_id = node_ids[i + 1]
-
-#         if curr_node_id == next_node_id:
-#             continue
-
-
-#         with connection:
-#             with connection.cursor() as cursor:
-#                 #Uses pg_routing to route between the start node and end node on the HERE
-#                 #links network. Returns inputs and an array of link_dirs and a unioned line
-#                 select_sql = '''
-#                     WITH results as (
-#                         SELECT *
-#                         FROM pgr_dijkstra(
-#                             'SELECT id, source::int, target::int, length::int as cost from here.routing_streets_name', %(node_start)s,
-#                                 %(node_end)s)
-#                     )
-
-#                     SELECT %(node_start)s, %(node_end)s, array_agg(st_name),array_agg(link_dir), ST_AsGeoJSON(ST_union(ST_linemerge(geom))) as geometry
-#                     FROM results
-#                     inner join here.routing_streets_name on edge = id'''
-#                 cursor.execute(select_sql, {"node_start": curr_node_id, "node_end": next_node_id})
-#                 source, target, path, link_dirs, geometry = cursor.fetchone()
-
-
-#         shortest_link_data = {"source": source, "target": target,
-#             "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
-#         optimal_links_data_list.append(shortest_link_data)
-
-#     connection.close()
-#     return jsonify(optimal_links_data_list)
-
-
 @app.route('/travel-data-file', methods=['POST'])
 def get_links_travel_data_file():
     """

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -146,15 +146,22 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
                 WITH results as (
                     SELECT *
                     FROM pgr_dijkstra(
-                        'SELECT id, source::int, target::int, length::int as cost from here.routing_streets_name', %(node_start)s,
-                            %(node_end)s)
+                        'SELECT id, source::int, target::int, length::int AS cost FROM here.routing_streets_name',
+                        %(node_start)s,
+                        %(node_end)s
+                    )
                 )
 
-                SELECT %(node_start)s, %(node_end)s, array_agg(st_name),array_agg(link_dir), ST_AsGeoJSON(ST_union(ST_linemerge(geom))) as geometry
+                SELECT 
+                    %(node_start)s,
+                    %(node_end)s,
+                    array_agg(st_name),
+                    array_agg(link_dir),
+                    ST_AsGeoJSON(ST_union(ST_linemerge(geom))) AS geometry
                 FROM results
-                inner join here.routing_streets_name on edge = id'''
+                INNER JOIN here.routing_streets_name on edge = id'''
             cursor.execute(select_sql, {"node_start": from_node_id, "node_end": to_node_id})
-            source, target, path, link_dirs, geometry = cursor.fetchall()[0]
+            ( source, target, path, link_dirs, geometry ) = cursor.fetchall()[0]
             print(type(geometry))
 
     shortest_link_data = {"source": source, "target": target,
@@ -201,13 +208,20 @@ def get_links_between_multi_nodes():
                     WITH results as (
                         SELECT *
                         FROM pgr_dijkstra(
-                            'SELECT id, source::int, target::int, length::int as cost from here.routing_streets_name', %(node_start)s,
-                                %(node_end)s)
+                            'SELECT id, source::int, target::int, length::int AS cost FROM here.routing_streets_name',
+                            %(node_start)s,
+                            %(node_end)s
+                        )
                     )
 
-                    SELECT %(node_start)s, %(node_end)s, array_agg(st_name),array_agg(link_dir), ST_AsGeoJSON(ST_union(ST_linemerge(geom))) as geometry
+                    SELECT
+                        %(node_start)s,
+                        %(node_end)s,
+                        array_agg(st_name),
+                        array_agg(link_dir),
+                        ST_AsGeoJSON(ST_union(ST_linemerge(geom))) AS geometry
                     FROM results
-                    inner join here.routing_streets_name on edge = id'''
+                    INNER JOIN here.routing_streets_name ON edge = id'''
                 cursor.execute(select_sql, {"node_start": curr_node_id, "node_end": next_node_id})
                 source, target, path, link_dirs, geometry = cursor.fetchall()[0] 
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -164,8 +164,15 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
             source, target, path, link_dirs, geometry = cursor.fetchone()
             print(type(geometry))
 
+
+    #parse path
+    unique = []
+    for stname in path:
+        if stname not in unique:
+            unique.append(stname)
+
     shortest_link_data = {"source": source, "target": target,
-        "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
+        "path_name": str(unique), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
 
     connection.close()
     

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -162,20 +162,21 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
                 INNER JOIN here.routing_streets_name on edge = id'''
             cursor.execute(select_sql, {"node_start": from_node_id, "node_end": to_node_id})
             source, target, path, link_dirs, geometry = cursor.fetchone()
-            print(type(geometry))
 
-
-    #parse path
-    unique = []
+    # Set of street names used in path
+    uniqueNames = []
     for stname in path:
-        if stname not in unique:
-            unique.append(stname)
+        if stname not in uniqueNames:
+            uniqueNames.append(stname)
 
-    shortest_link_data = {"source": source, "target": target,
-        "path_name": str(unique), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
-
+    shortest_link_data = {
+        "source": source, 
+        "target": target,
+        "path_name": ', '.join(uniqueNames), 
+        "link_dirs": link_dirs, 
+        "geometry": json.loads(geometry) # parse json to object here; it will be dumped back to text in a second
+    }
     connection.close()
-    
     return jsonify(shortest_link_data)
 
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -154,7 +154,7 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
                 FROM results
                 inner join here.routing_streets_name on edge = id'''
             cursor.execute(select_sql, {"node_start": from_node_id, "node_end": to_node_id})
-            source, target, path, link_dirs, geometry = cursor.fetchall()[0]
+            source, target, path, link_dirs, geometry = cursor.fetchone()
             print(type(geometry))
 
     shortest_link_data = {"source": source, "target": target,
@@ -165,59 +165,59 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
     return jsonify(shortest_link_data)
 
 
-@app.route('/link-nodes', methods=['POST'])
-def get_links_between_multi_nodes():
-    """
-    Get the shortest length link connecting the given nodes in order.
-    This function filters links using ST_Intersects and sort them using the
-    length attribute of the link object.
-    If any two consecutive nodes in the list are the same, they are skipped.
-    This function will call abort with response code 400 when the given node_ids can not be cast to an integer
-    or no link exists between the two nodes.
+# @app.route('/link-nodes', methods=['POST'])
+# def get_links_between_multi_nodes():
+#     """
+#     Get the shortest length link connecting the given nodes in order.
+#     This function filters links using ST_Intersects and sort them using the
+#     length attribute of the link object.
+#     If any two consecutive nodes in the list are the same, they are skipped.
+#     This function will call abort with response code 400 when the given node_ids can not be cast to an integer
+#     or no link exists between the two nodes.
 
-    :return: JSON representing an array of link objects, which are the shortest links connecting given points.
-            Link object keys: link_dir(str), link_id(int), st_name(str),
-            source(int), target(int), length(float),
-            geometry(geom{type(str), coordinates(list[int])})
-    """
-    node_ids = parse_get_links_between_multi_nodes_request_body(request.json)
-    optimal_links_data_list = []
+#     :return: JSON representing an array of link objects, which are the shortest links connecting given points.
+#             Link object keys: link_dir(str), link_id(int), st_name(str),
+#             source(int), target(int), length(float),
+#             geometry(geom{type(str), coordinates(list[int])})
+#     """
+#     node_ids = parse_get_links_between_multi_nodes_request_body(request.json)
+#     optimal_links_data_list = []
 
-    connection = getConnection()
+#     connection = getConnection()
 
-    for i in range(len(node_ids) - 1):
-        curr_node_id = node_ids[i]
-        next_node_id = node_ids[i + 1]
+#     for i in range(len(node_ids) - 1):
+#         curr_node_id = node_ids[i]
+#         next_node_id = node_ids[i + 1]
 
-        if curr_node_id == next_node_id:
-            continue
-
-
-        with connection:
-            with connection.cursor() as cursor:
-                #Uses pg_routing to route between the start node and end node on the HERE
-                #links network. Returns inputs and an array of link_dirs and a unioned line
-                select_sql = '''
-                    WITH results as (
-                        SELECT *
-                        FROM pgr_dijkstra(
-                            'SELECT id, source::int, target::int, length::int as cost from here.routing_streets_name', %(node_start)s,
-                                %(node_end)s)
-                    )
-
-                    SELECT %(node_start)s, %(node_end)s, array_agg(st_name),array_agg(link_dir), ST_AsGeoJSON(ST_union(ST_linemerge(geom))) as geometry
-                    FROM results
-                    inner join here.routing_streets_name on edge = id'''
-                cursor.execute(select_sql, {"node_start": curr_node_id, "node_end": next_node_id})
-                source, target, path, link_dirs, geometry = cursor.fetchall()[0] 
+#         if curr_node_id == next_node_id:
+#             continue
 
 
-        shortest_link_data = {"source": source, "target": target,
-            "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
-        optimal_links_data_list.append(shortest_link_data)
+#         with connection:
+#             with connection.cursor() as cursor:
+#                 #Uses pg_routing to route between the start node and end node on the HERE
+#                 #links network. Returns inputs and an array of link_dirs and a unioned line
+#                 select_sql = '''
+#                     WITH results as (
+#                         SELECT *
+#                         FROM pgr_dijkstra(
+#                             'SELECT id, source::int, target::int, length::int as cost from here.routing_streets_name', %(node_start)s,
+#                                 %(node_end)s)
+#                     )
 
-    connection.close()
-    return jsonify(optimal_links_data_list)
+#                     SELECT %(node_start)s, %(node_end)s, array_agg(st_name),array_agg(link_dir), ST_AsGeoJSON(ST_union(ST_linemerge(geom))) as geometry
+#                     FROM results
+#                     inner join here.routing_streets_name on edge = id'''
+#                 cursor.execute(select_sql, {"node_start": curr_node_id, "node_end": next_node_id})
+#                 source, target, path, link_dirs, geometry = cursor.fetchone()
+
+
+#         shortest_link_data = {"source": source, "target": target,
+#             "path_name": str(path), "link_dirs": link_dirs, "geometry": json.loads(geometry)}
+#         optimal_links_data_list.append(shortest_link_data)
+
+#     connection.close()
+#     return jsonify(optimal_links_data_list)
 
 
 @app.route('/travel-data-file', methods=['POST'])

--- a/frontend/src/actions.js
+++ b/frontend/src/actions.js
@@ -99,7 +99,7 @@ export function getLinksBetweenNodes(map, sequences){
         } ).filter(v=>v)
         Promise.all( nodePairs.map( pair => (
             axios.get(`${domain}/link-nodes/${pair.from}/${pair.to}`)
-        ) ) ).then( data => {
+        ) ) ).then( responses => {
             console.log(data)
             if (data) {
                 map.displayLinks( data, seqIndex )

--- a/frontend/src/actions.js
+++ b/frontend/src/actions.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 axios.defaults.withCredentials = true;
 /* remote domain and local test domain */
 const domain = process.env.NODE_ENV === 'development' ? 
-    'http://127.0.0.1:5007' : 'https://10.160.2.198/tt-request-backend';
+    'http://127.0.0.1:5000' : 'https://10.160.2.198/tt-request-backend';
 const fileDownload = require('js-file-download');
 
 const handleResponseError = (err) => {
@@ -95,14 +95,17 @@ export const updateClosestNode = (page, data) => {
 export function getLinksBetweenNodes(map, sequences){
     sequences.forEach((nodes,seqIndex) => {
         const nodePairs = nodes.map( (node,i) => {
-            if ( i > 0 ) return { from: node.nodeId, to: nodes[i-1].nodeId }
+            if ( i > 0 ) return { from: nodes[i-1].nodeId, to: node.nodeId }
+            return undefined
         } ).filter(v=>v)
         Promise.all( nodePairs.map( pair => (
             axios.get(`${domain}/link-nodes/${pair.from}/${pair.to}`)
         ) ) ).then( responses => {
-            console.log(data)
-            if (data) {
-                map.displayLinks( data, seqIndex )
+            if ( responses.every( response => response.status === 200 ) ) {
+                map.displayLinks(
+                    responses.map( response => response.data ),
+                    seqIndex
+                )
             } else {
                 alert("Failed to fetch links between nodes")
             }

--- a/frontend/src/components/Map/index.jsx
+++ b/frontend/src/components/Map/index.jsx
@@ -128,18 +128,17 @@ export default class Map extends React.Component {
     };
 
     /* this function is called only by action.js after full link data is fetch */
-    displayLinks(linkDataArr, sequence, finished) {
-        this.drawLinks(linkDataArr, sequence);
+    displayLinks(linkDataArr, sequence) {
+        this.drawLinks(linkDataArr, sequence)
         // This is where links are set
-        this.setState({
-            linksData: this.state.linksData.concat([linkDataArr]),
-            linksOnMap: true
-        }, function () {
-            if (finished) {
-                this.enableInteractions();
-            }
-        });
-        this.props.onLinkUpdate(linkDataArr);
+        this.setState(
+            {
+                linksData: this.state.linksData.concat([linkDataArr]),
+                linksOnMap: true
+            },
+            () => this.enableInteractions() // re-enables buttons
+        )
+        this.props.onLinkUpdate(linkDataArr)
     };
     // check if there is already a link drawn in the reverse direction
     checkIfLinkDirDrawn(checkCoor, bidirection, other) {


### PR DESCRIPTION
## What this pull request accomplishes:
Moves SQL queries and data parsing inline, for the following functions:
- `get_links_between_two_nodes`
- `get_links_between_multi_nodes`

`parse_get_links_btwn_nodes` in `parse_util.py` deleted, as it is no longer needed

## Issue(s) this solves:
#23

## What, in particular, needs to reviewed:
- `routes.py`: containing both functions

## Notes:
The format of the final data structure is not finalized, works with current frontend
