### PR TITLE
Drop unused python packages from requirements

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -4,13 +4,11 @@ from flask_cors import CORS
 from config import Config
 from os import environ
 from datetime import datetime
-from pytz import timezone
 
 app = Flask(__name__)
 CORS(app=app, supports_credentials=True)
 app.config.from_object(Config)
 
-TIMEZONE = timezone('US/Eastern')
 FULL_DATE_TIME_FORMAT = "%Y-%m-%d %H:%M"
 DATE_FORMAT = "%Y-%m-%d"
 TIME_FORMAT = "%H:%M"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,32 +1,6 @@
-atomicwrites==1.4.0
-attrs==20.3.0
-click==7.1.2
-colorama==0.4.4
-Flask==1.1.2
-Flask-Cors==3.0.9
-Flask-SQLAlchemy==2.4.4
-GeoAlchemy2==0.8.4
+flask==1.1.2
+flask_cors==3.0.9
 gunicorn==20.1.0
-iniconfig==1.1.1
-itsdangerous==1.1.0
-Jinja2==2.11.2
-MarkupSafe==1.1.1
 packaging==20.7
-# IMPORTANT !!!!! pg8000 version MUST BE <= 1.16.5. VERSION 1.16.6 HAS CONFLICT WITH SQLALCHEMY
-# UNLESS SQLALCHEMY HAS AN UPDATE ADDRESSING THIS ISSUE, ENFORCE 1.16.5 VERSION AND IGNORE UPDATE WARNINGS
-pg8000==1.16.5
-pluggy==0.13.1
 psycopg2==2.9.6
-py==1.9.0
-pyparsing==2.4.7
-pytest==6.1.2
-pytest-dotenv==0.5.2
 python-dotenv==0.15.0
-pytz==2020.4
-scramp==1.2.0
-six==1.15.0
-testing.common.database==2.0.3
-testing.postgresql==1.3.0
-toml==0.10.2
-Werkzeug==1.0.1
-XlsxWriter==1.3.7

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+setuptools=59.6.0
 flask==1.1.2
 flask_cors==3.0.9
 gunicorn==20.1.0


### PR DESCRIPTION
Some of these still end up getting installed as dependencies but there's no need for us to track that. 