### PR TITLE
Skip requesting invalid range combos

### DIFF
--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -48,6 +48,25 @@ export class DateRange extends Factor {
     get endDateFormatted(){
         return DateRange.dateFormatted(this.#endDate)
     }
+    daysInRange(daysOptions){ // number of days covered by this dateRange
+        // TODO this will need to be revisited with the holiday options enabled
+        if( ! (this.isComplete && daysOptions.isComplete) ){
+            return undefined
+        }
+        // iterate each day in the range
+        let d = new Date(this.#startDate.valueOf())
+        let dayCount = 0
+        while(d < this.#endDate){
+            let dow = d.getUTCDay() 
+            let isodow = dow == 0 ? 7 : dow
+            if( daysOptions.hasDay(isodow) ){
+                dayCount ++
+            }
+            // incrememnt, modified in-place
+            d.setUTCDate(d.getUTCDate() + 1)
+        }
+        return dayCount
+    }
 }
 
 function DateRangeElement({dateRange}){

--- a/frontend/src/days.js
+++ b/frontend/src/days.js
@@ -2,19 +2,19 @@ import { useContext } from 'react'
 import { Factor } from './factor.js'
 import { DataContext } from './Layout'
 
-const daymap = {
-    1: 'Monday',
-    2: 'Tuesday',
-    3: 'Wednesday',
-    4: 'Thursday',
-    5: 'Friday',
-    6: 'Saturday',
-    7: 'Sunday'
-}
+const daylist = [
+    { iso: 1, js: 1, label: 'Monday' },
+    { iso: 2, js: 2, label: 'Tuesday' },
+    { iso: 3, js: 3, label: 'Wednesday' },
+    { iso: 4, js: 4, label: 'Thursday' },
+    { iso: 5, js: 5, label: 'Friday' },
+    { iso: 6, js: 6, label: 'Saturday' },
+    { iso: 7, js: 0, label: 'Sunday' } // note the different numeric representation
+]
 
 export class Days extends Factor {
     // initialize with all days included
-    #days = new Set(Object.keys(daymap).map(n => parseInt(n)))
+    #days = new Set(daylist.map(d=>d.iso))
     constructor(dataContext){
         super(dataContext)
     }
@@ -25,10 +25,8 @@ export class Days extends Factor {
         return this.#days.size > 0
     }
     addDay(number){
-        console.log('add',number)
-        if(Object.keys(daymap).includes(String(number))){
+        if( daylist.map(d=>d.iso).includes(parseInt(number)) ){
             this.#days.add(parseInt(number))
-            console.log('it worked')
         }
     }
     removeDay(number){
@@ -41,9 +39,9 @@ export class Days extends Factor {
         if(this.#days.size == 7){
             return 'all days of the week'
         } else if(this.#days.size > 0){
-            return Object.entries(daymap).filter(([num,name])=>{
-                return this.#days.has(parseInt(num))
-            }).map(([num,name])=>name).join(', ')
+            return daylist
+                .filter( ({iso}) => this.#days.has(iso) )
+                .map( ({label}) => label ).join(', ')
         }
         return 'no days selected'
     }
@@ -53,7 +51,7 @@ export class Days extends Factor {
 function DaysElement({days}){
     const { logActivity } = useContext(DataContext)
     if(days.isActive){
-        return Object.entries(daymap).map( ([num,name]) => (
+        return daylist.map( ({ iso: num, label: name }) => (
             <div key={num}>
                 <input name={name}
                     type='checkbox'

--- a/frontend/src/timeRange.js
+++ b/frontend/src/timeRange.js
@@ -53,6 +53,10 @@ export class TimeRange extends Factor {
     get endTimeFormatted(){
         return TimeRange.timeFormatted(this.#endTime)
     }
+    get hoursInRange(){ // how many hours are in the timeRange?
+        if(! this.isComplete){ return undefined }
+        return this.#endTime.getHours() - this.#startTime.getHours()
+    }
 }
 
 function TimeRangeElement({timeRange}){

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -29,6 +29,10 @@ export class TravelTimeQuery {
     get dateRange(){ return this.#dateRange }
     get days(){ return this.#days }
     async fetchData(){
+        console.log(this.hoursInRange)
+        if( this.hoursInRange < 1 ){
+            return this.#travelTime = -999
+        }
         return fetch(`${domain}/${this.URI}`)
             .then( response => response.json() )
             .then( data => {
@@ -38,6 +42,9 @@ export class TravelTimeQuery {
     get hasData(){
         return Boolean(this.#travelTime)
     }
+    get hoursInRange(){ // number of hours covered by query options
+        return this.timeRange.hoursInRange * this.dateRange.daysInRange(this.days)
+    }
     resultsRecord(type='json'){
         const record = {
             URI: this.URI,
@@ -45,6 +52,7 @@ export class TravelTimeQuery {
             timeRange: `"${this.timeRange.name}"`,
             dateRange: `"${this.dateRange.name}"`,
             daysOfWeek: `"${this.days.name}"`,
+            hoursInRange: this.hoursInRange,
             mean_travel_time_minutes: this.#travelTime
         }
         if(type=='json'){
@@ -55,6 +63,6 @@ export class TravelTimeQuery {
         return 'invalid type requested'
     }
     static csvHeader(){
-        return 'URI,corridor,timeRange,dateRange,daysOfWeek,mean_travel_time_minutes'
+        return 'URI,corridor,timeRange,dateRange,daysOfWeek,hoursPossible,mean_travel_time_minutes'
     }
 }


### PR DESCRIPTION
Leaves them in the output with `-999` as the travel time. Added a field to indicate the number of hours within the range of the request, which in these cases will be zero. 

Closes #67 