### PR TITLE
Estimate the number of probe vehicles available in the scope of the request

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The other fields may require some explanation:
 | `mean_travel_time_minutes` | The mean travel time in minutes is given as a floating point number rounded to two decimal places. Where insufficient data was available to complete the request, the value will be null, and in cases where the request was impossible a value of -999 will be assigned. (See `hoursInRange` below). |
 | `URI` | The URI is the API endpoint that corresponds to this exect request. It may be of little use to some end users but may help us to reproduce the request and verify data quality. It can also serve as a unique ID. |
 | `hoursInRange` | The total number of hours that are theoretically within the scope of this request. This does not imply that data is/was available at all times. It's possible to construct requests with zero hours in range such as e.g `2023-01-01` to `2023-01-02`, Mondays only (There's only one Sunday in that range). Impossible combinations are included in the output for clarity and completeness but are not actually executed against the API and should return an error. |
+| `estimatedVehicleCount` | A very rough estimate of the number of actual vehicles traversing the corridor within the given temporal bounds. Includes partial trips through the corridor and may be subject to additional caveats which we are still exploring. |
 
 
 ## Methodology

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -89,7 +89,7 @@ def aggregate_travel_times(start_node, end_node, start_time, end_time, start_dat
 
     include_holidays = include_holidays.lower() in ['true', 'yes', 't']
 
-    dow_list = re.findall(r"[1-7]", dow_str)
+    dow_list = list(set([int(numstr) for numstr in re.findall(r"[1-7]", dow_str)]))
     if len(dow_list) == 0:
         return jsonify({'error': "dow list does not contain valid characters, i.e. [1-7]"})
 

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -7,6 +7,7 @@ export class TravelTimeQuery {
     #days
     #holidayOption
     #travelTime
+    #estimatedSample
     constructor({corridor,timeRange,dateRange,days,holidayOption}){
         this.#corridor = corridor
         this.#timeRange = timeRange
@@ -40,6 +41,7 @@ export class TravelTimeQuery {
             .then( response => response.json() )
             .then( data => {
                 this.#travelTime = data.travel_time
+                this.#estimatedSample = data.estimated_vehicle_count
             } )
     }
     get hasData(){
@@ -59,6 +61,7 @@ export class TravelTimeQuery {
             daysOfWeek: this.days.name,
             holidaysIncluded: this.#holidayOption.holidaysIncluded,
             hoursInRange: this.hoursInRange,
+            estimatedVehicleCount: this.#estimatedSample,
             mean_travel_time_minutes: this.#travelTime
         }
         if(type=='json'){
@@ -77,6 +80,6 @@ export class TravelTimeQuery {
         return 'invalid type requested'
     }
     static csvHeader(){
-        return 'URI,corridor,timeRange,dateRange,daysOfWeek,holidaysIncluded,hoursPossible,mean_travel_time_minutes'
+        return 'URI,corridor,timeRange,dateRange,daysOfWeek,holidaysIncluded,hoursPossible,estimatedSample,mean_travel_time_minutes'
     }
 }


### PR DESCRIPTION
This estimates the sample size for travel time queries by calculating the total amount of time that all probe vehicles spend in the corridor (subject to the various temporal query params). Given that we know the average travel time, if we assume that the vehicles actually traverse most of the corridor then the total probe time divided by the average travel time is the number of vehicles that should have traversed the corridor within this span. 

This does not consider the various threshold criteria for inclusion in the congestion-network-based travel time aggregation. Thus, if anything this will be an overestimate for current methods. 

We may eventually want to use this as a filter to determine what queries to deny due to insufficient data. Or perhaps rather to suggest to data consumers some minimum threshold for reliability. 