### PR TITLE
Handle missing cross-streets in corridor name

### DIFF
--- a/frontend/src/corridor.js
+++ b/frontend/src/corridor.js
@@ -49,13 +49,10 @@ export class Corridor extends Factor {
             // routing should be done
             let start = difference(this.intersections[0].streetNames,this.viaStreets)
             let end = difference(this.intersections[1].streetNames,this.viaStreets)
-            if(start.size == 0){
-                start.add(this.intersections[0].displayCoords)
-            }
-            if(end.size == 0){
-                end.add(this.intersections[1].displayCoords)
-            }
-            return `${[...start].join(' & ')} to ${[...end].join(' & ')} via ${[...this.viaStreets].join(' & ')}`
+            // no cross-street of a different name
+            if(start.size == 0){ start.add(this.intersections[0].displayCoords) }
+            if(end.size == 0){ end.add(this.intersections[1].displayCoords) }
+            return `${[...this.viaStreets].join(' & ')} from ${[...start].join(' & ')} to ${[...end].join(' & ')}`
         }else if(this.#intersections.length == 2){ // but no via streets (yet?)
             let start = [...this.intersections[0].streetNames].join(' & ')
             let end = [...this.intersections[1].streetNames].join(' & ')

--- a/frontend/src/corridor.js
+++ b/frontend/src/corridor.js
@@ -46,8 +46,15 @@ export class Corridor extends Factor {
         if(this.#intersections.length == 1){
             return `Incomplete corridor starting from ${this.intersections[0].description}`
         }else if(this.#intersections.length == 2 && this.viaStreets.size > 0){
+            // routing should be done
             let start = difference(this.intersections[0].streetNames,this.viaStreets)
             let end = difference(this.intersections[1].streetNames,this.viaStreets)
+            if(start.size == 0){
+                start.add(this.intersections[0].displayCoords)
+            }
+            if(end.size == 0){
+                end.add(this.intersections[1].displayCoords)
+            }
             return `${[...start].join(' & ')} to ${[...end].join(' & ')} via ${[...this.viaStreets].join(' & ')}`
         }else if(this.#intersections.length == 2){ // but no via streets (yet?)
             let start = [...this.intersections[0].streetNames].join(' & ')

--- a/frontend/src/intersection.js
+++ b/frontend/src/intersection.js
@@ -11,6 +11,10 @@ export class Intersection {
     }
     get id(){ return this.#id }
     get latlng(){ return { lat: this.#lat, lng: this.#lng } }
+    get displayCoords(){
+        // for display purposes only
+        return `${this.#lng.toFixed(5)}, ${this.#lat.toFixed(5)}`
+    }
     get description(){
         return [...this.#streetNames].join(' & ')
     }


### PR DESCRIPTION
closes #93 

It's not the absolute best solution but at least it's robust and unambiguous. 

Also changes corridor name ordering so the _via_ street comes first.