### PR TITLE
Restore query state from previous results file

### DIFF
--- a/backend/app/get_node.py
+++ b/backend/app/get_node.py
@@ -1,0 +1,31 @@
+import json
+from app.db import getConnection
+
+sql = '''
+SELECT 
+    cg_nodes.node_id::int,
+    ST_AsGeoJSON(cg_nodes.geom) AS geom,
+    array_agg(DISTINCT InitCap(streets.st_name)) FILTER (WHERE streets.st_name IS NOT NULL) AS street_names
+FROM congestion.network_nodes AS cg_nodes
+JOIN here.routing_nodes_21_1 AS here_nodes USING (node_id)
+JOIN here_gis.streets_att_21_1 AS streets USING (link_id)
+WHERE node_id = %(node_id)s
+GROUP BY
+    cg_nodes.node_id,
+    cg_nodes.geom;
+'''
+
+# TODO code could use some tidying up
+def get_node(node_id):
+    with getConnection() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(sql, {"node_id": node_id})
+            nodes = []
+            for node_id, geojson, street_names in cursor.fetchall():
+                nodes.append( {
+                    'node_id': node_id,
+                    'street_names': street_names,
+                    'geometry': json.loads(geojson)
+                } )
+    connection.close()
+    return nodes[0] if len(nodes) > 0 else {}

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -4,6 +4,7 @@ from flask import jsonify
 from app import app
 from app.db import getConnection
 from app.get_closest_nodes import get_closest_nodes
+from app.get_node import get_node
 from app.get_travel_time import get_travel_time
 
 from app.get_links import get_links
@@ -25,6 +26,14 @@ def closest_node(longitude,latitude):
         return jsonify({'error': "Longitude and latitude must be decimal numbers!"})
     return jsonify(get_closest_nodes(longitude,latitude))
 
+# test URL /node/30357505
+@app.route('/node/<node_id>', methods=['GET'])
+def node(node_id):
+    try:
+        node_id = int(node_id)
+    except:
+        return jsonify({'error': "node_id should be an integer"})
+    return jsonify(get_node(node_id))
 
 # test URL /link-nodes/30421154/30421153
 #shell function - outputs json for use on frontend

--- a/frontend/src/Sidebar/index.jsx
+++ b/frontend/src/Sidebar/index.jsx
@@ -15,7 +15,7 @@ export default function SidebarContent(){
             onDragEnter={ e => { e.stopPropagation(); e.preventDefault() } }
             onDragOver={ e => { e.stopPropagation(); e.preventDefault() } }
             onDrop={ event => {
-                restoreStateFromFile(event,data)
+                restoreStateFromFile(event,data,logActivity)
                     .then( logActivity('state restored from file') ) // not working?
             } }
         >

--- a/frontend/src/Sidebar/index.jsx
+++ b/frontend/src/Sidebar/index.jsx
@@ -5,11 +5,16 @@ import FactorContainer from './FactorContainer'
 import BigButton from './BigButton'
 import FactorList from './FactorList'
 import { TravelTimeQuery } from '../travelTimeQuery.js'
+import { restoreStateFromFile } from './restoreStateFromFile.js'
 import './sidebar.css'
 
 export default function SidebarContent(){
     return (
-        <div className="sidebarContent">
+        <div className="sidebarContent"
+            onDragEnter={ e => { e.stopPropagation(); e.preventDefault() } }
+            onDragOver={ e => { e.stopPropagation(); e.preventDefault() } }
+            onDrop={restoreStateFromFile}
+        >
             <Welcome/>
             <CorridorsContainer/>
             <div className='big-math-symbol'>&#xd7;</div>

--- a/frontend/src/Sidebar/index.jsx
+++ b/frontend/src/Sidebar/index.jsx
@@ -9,11 +9,15 @@ import { restoreStateFromFile } from './restoreStateFromFile.js'
 import './sidebar.css'
 
 export default function SidebarContent(){
+    const { data, logActivity } = useContext(DataContext)
     return (
         <div className="sidebarContent"
             onDragEnter={ e => { e.stopPropagation(); e.preventDefault() } }
             onDragOver={ e => { e.stopPropagation(); e.preventDefault() } }
-            onDrop={restoreStateFromFile}
+            onDrop={ event => {
+                restoreStateFromFile(event,data)
+                    .then( logActivity('state restored from file') ) // not working?
+            } }
         >
             <Welcome/>
             <CorridorsContainer/>
@@ -45,7 +49,7 @@ function Results(){
                     setIsFetchingData(true)
                     data.fetchAllResults().then( () => {
                         setIsFetchingData(false)
-                        setResults(data.travelTimeQueries) 
+                        setResults(data.travelTimeQueries)
                     } )
                 }}>
                     Submit Query

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,4 +1,3 @@
-
 const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})\/(?<holidays>true|false)\/(?<dow>\d+)/
 
 export async function restoreStateFromFile(fileDropEvent,stateData){
@@ -47,6 +46,13 @@ export async function restoreStateFromFile(fileDropEvent,stateData){
             }else{
                 stateData.excludeHolidays()
             }
+            // days of week
+            // TODO: drop the default selection?
+            [... new Set(URIs.map(uri=>uri.dow))].forEach( dows => {
+                let daysFactor = stateData.createDays()
+                let days = dows.split('').map(Number)
+                daysFactor.setFromSet(new Set(days))
+            } )
         } )
 }
 

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,5 +1,5 @@
 
-const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})/
+const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})\/(?<holidays>true|false)\/(?<dow>\d+)/
 
 export async function restoreStateFromFile(fileDropEvent,stateData){
     fileDropEvent.stopPropagation()
@@ -20,7 +20,7 @@ export async function restoreStateFromFile(fileDropEvent,stateData){
             distinctPairs(URIs,'startNode','endNode')
                 .forEach( ({startNode,endNode}) => {
                     console.log('unhandled corridor nodes',startNode,endNode)
-                    /* TODO do soemthing like
+                    /* TODO do something like - but more complicated!
                     let corridor = stateData.createCorridor()
                     corridor.addIntersection(startNode)
                     corridor.addIntersection(endNode)
@@ -38,10 +38,21 @@ export async function restoreStateFromFile(fileDropEvent,stateData){
                     dateRange.setStartDate(new Date(Date.parse(startDate)))
                     dateRange.setEndDate(new Date(Date.parse(endDate)))
                 } )
+            // holiday inclusion
+            let holidays = new Set(URIs.map(uri => uri.holidays))
+            if(holidays.has('true') && holidays.has('false')){
+                stateData.includeAndExcludeHolidays()
+            }else if(holidays.has('true')){
+                stateData.includeHolidays()
+            }else{
+                stateData.excludeHolidays()
+            }
         } )
 }
 
-function distinctPairs(list,prop1,prop2){
+// get distinct value pairs from a list of objects by their property names
+// all are strings
+function distinctPairs(list, prop1, prop2){
     let distinctKeys = new Set( list.map(o => `${o[prop1]} | ${o[prop2]}`) )
     return [...distinctKeys].map( k => {
         let vals = k.split(' | ')

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,11 +1,36 @@
-export function restoreStateFromFile(fileDropEvent){
+
+const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)/
+
+export async function restoreStateFromFile(fileDropEvent,stateData){
     fileDropEvent.stopPropagation()
     fileDropEvent.preventDefault()
-    // only handle one at a time
+
+    // only handle one file at a time
     let file = fileDropEvent.dataTransfer.files[0]
-    console.log(file)
-    if( ! file.type == 'application/json' ) { return }
-    let reader = new FileReader()
-    reader.onload = e => { console.log(JSON.parse(e.target.result)) }
-    reader.readAsText(file)
+
+    // TODO: handle CSV
+    if( file.type != 'application/json' ) { return }
+
+    return file.text()
+        .then( text => JSON.parse(text) )
+        .then( data => {
+            // should be a list of objects each with a URI property
+            let URIs = data.map( r => r.URI.match(URIpattern).groups )
+            console.log(URIs)
+
+            distinctPairs(URIs,'startTime','endTime')
+                .forEach( ({startTime,endTime}) => {
+                    let timeRange = stateData.createTimeRange()
+                    timeRange.setStartTime(startTime)
+                    timeRange.setEndTime(endTime)
+                } )
+        } )
+}
+
+function distinctPairs(list,prop1,prop2){
+    let distinctKeys = new Set( list.map(o => `${o[prop1]} | ${o[prop2]}`) )
+    return [...distinctKeys].map( k => {
+        let vals = k.split(' | ')
+        return { [prop1]: vals[0], [prop2]: vals[1] }
+    } )
 }

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -16,8 +16,16 @@ export async function restoreStateFromFile(fileDropEvent,stateData){
         .then( data => {
             // should be a list of objects each with a URI property
             let URIs = data.map( r => r.URI.match(URIpattern).groups )
-            console.log(URIs)
 
+            distinctPairs(URIs,'startNode','endNode')
+                .forEach( ({startNode,endNode}) => {
+                    console.log('unhandled corridor nodes',startNode,endNode)
+                    /* TODO do soemthing like
+                    let corridor = stateData.createCorridor()
+                    corridor.addIntersection(startNode)
+                    corridor.addIntersection(endNode)
+                    */
+                } )
             distinctPairs(URIs,'startTime','endTime')
                 .forEach( ({startTime,endTime}) => {
                     let timeRange = stateData.createTimeRange()

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,7 +1,7 @@
 import { Intersection } from '../intersection.js'
 import { domain } from '../domain.js'
 
-const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})\/(?<holidays>true|false)\/(?<dow>\d+)/
+const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})\/(?<holidays>true|false)\/(?<dow>\d+)/g
 
 export async function restoreStateFromFile(fileDropEvent,stateData,logActivity){
     fileDropEvent.stopPropagation()
@@ -10,15 +10,10 @@ export async function restoreStateFromFile(fileDropEvent,stateData,logActivity){
     // only handle one file at a time
     let file = fileDropEvent.dataTransfer.files[0]
 
-    // TODO: handle CSV
-    if( file.type != 'application/json' ) { return }
-
     return file.text()
-        .then( text => JSON.parse(text) )
-        .then( data => {
+        .then( textData => {
             // should be a list of objects each with a URI property
-            let URIs = data.map( r => r.URI.match(URIpattern).groups )
-
+            let URIs = [...textData.matchAll(URIpattern)].map(m=>m.groups)
             distinctPairs(URIs,'startNode','endNode')
                 .forEach( ({startNode,endNode}) => {
                     let corridor = stateData.createCorridor()

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,0 +1,11 @@
+export function restoreStateFromFile(fileDropEvent){
+    fileDropEvent.stopPropagation()
+    fileDropEvent.preventDefault()
+    // only handle one at a time
+    let file = fileDropEvent.dataTransfer.files[0]
+    console.log(file)
+    if( ! file.type == 'application/json' ) { return }
+    let reader = new FileReader()
+    reader.onload = e => { console.log(JSON.parse(e.target.result)) }
+    reader.readAsText(file)
+}

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,5 +1,5 @@
 
-const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)/
+const URIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})/
 
 export async function restoreStateFromFile(fileDropEvent,stateData){
     fileDropEvent.stopPropagation()
@@ -23,6 +23,12 @@ export async function restoreStateFromFile(fileDropEvent,stateData){
                     let timeRange = stateData.createTimeRange()
                     timeRange.setStartTime(startTime)
                     timeRange.setEndTime(endTime)
+                } )
+            distinctPairs(URIs,'startDate','endDate')
+                .forEach( ({startDate,endDate}) => {
+                    let dateRange = stateData.createDateRange()
+                    dateRange.setStartDate(new Date(Date.parse(startDate)))
+                    dateRange.setEndDate(new Date(Date.parse(endDate)))
                 } )
         } )
 }

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -48,10 +48,9 @@ export async function restoreStateFromFile(fileDropEvent,stateData){
             }
             // days of week
             // TODO: drop the default selection?
-            [... new Set(URIs.map(uri=>uri.dow))].forEach( dows => {
+            [... new Set(URIs.map(uri=>uri.dow))].forEach( dowsString => {
                 let daysFactor = stateData.createDays()
-                let days = dows.split('').map(Number)
-                daysFactor.setFromSet(new Set(days))
+                daysFactor.setFromSet(new Set(dowsString.split('').map(Number)))
             } )
         } )
 }

--- a/frontend/src/days.js
+++ b/frontend/src/days.js
@@ -38,6 +38,11 @@ export class Days extends Factor {
     hasDay(number){
         return this.#days.has(parseInt(number))
     }
+    setFromSet(dowSet){
+        const validDays = new Set([...weekday,...weekend])
+        let validDowSet = new Set([...dowSet].filter(v => validDays.has(v)))
+        this.#days = validDowSet
+    }
     get name(){
         if(this.#days.size == 7){
             return 'all days'

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -51,6 +51,7 @@ export class SpatialData {
         let days = new Days(this)
         this.#factors.push(days)
         days.activate()
+        return days
     }
     get segments(){
         return this.corridors.flatMap( c => c.segments )

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -33,6 +33,7 @@ export class SpatialData {
         let corridor = new Corridor(this)
         this.#factors.push(corridor)
         corridor.activate()
+        return corridor
     }
     createTimeRange(){
         let tr = new TimeRange(this)

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -38,6 +38,7 @@ export class SpatialData {
         let tr = new TimeRange(this)
         this.#factors.push(tr)
         tr.activate()
+        return tr
     }
     createDateRange(){
         let dr = new DateRange(this)

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -44,6 +44,7 @@ export class SpatialData {
         let dr = new DateRange(this)
         this.#factors.push(dr)
         dr.activate()
+        return dr
     }
     createDays(){
         let days = new Days(this)

--- a/frontend/src/timeRange.js
+++ b/frontend/src/timeRange.js
@@ -25,7 +25,7 @@ export class TimeRange extends Factor {
         return <TimeRangeElement timeRange={this}/>
     }
     static parseTime(timeString){
-        let match = timeString.match(/^(?<hours>\d{2})$/)
+        let match = timeString.match(/^(?<hours>\d{1,2})$/)
         if(match){
             let {hours} = match.groups
             return new Date(1970, 1, 1, parseInt(hours))


### PR DESCRIPTION
Closes #92

To restore the state of a previous query, just drag your previously downloaded results file over the browser and drop it anywhere in the side panel. The frontend then parses the URI values in the file and reconstructs the state of the app that would have generated those URIs. 

There is very little validation of the inputs or error handling in general. However the idea is to drop this feature in in a way that no one is likely to notice so as not to cause confusion. At least at first. Only data request reviewers will know about this feature for now.