### PR TITLE
Handle `null` travel times

### DIFF
--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -80,14 +80,15 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     with connection:
         with connection.cursor() as cursor:
             cursor.execute(agg_tt_query, query_params)
+            # travel_time may be null if there's insufficient data
             travel_time, = cursor.fetchone()
             cursor.execute(sample_size_query, query_params)
             probe_hours, = cursor.fetchone()
 
     connection.close()
     return {
-        'travel_time': float(travel_time), # may be null if insufficient data
+        'travel_time': None if travel_time is None else float(travel_time),
         'links': links,
-        'estimated_vehicle_count': float((probe_hours * 60) / travel_time),
+        'estimated_vehicle_count': None if travel_time is None else float((probe_hours * 60) / travel_time),
         'query_params': query_params
     }

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -66,7 +66,10 @@ export class TravelTimeQuery {
         record.set('hoursInRange', this.hoursInRange)
         record.set('estimatedVehicleCount', this.#estimatedSample)
         record.set('mean_travel_time_minutes', this.#travelTime)
-        record.set('mean_travel_time_seconds', 60* this.#travelTime)
+        record.set(
+            'mean_travel_time_seconds',
+            this.#travelTime ? 60 * this.#travelTime : null
+        )
 
         if(type=='json'){
             return Object.fromEntries(record) // can't JSONify maps


### PR DESCRIPTION
These can happen when coverage is poor. Was causing an error on the backend that the frontend wasn't expecting or handling. 

Backend now does not err.