### PR TITLE
Data-dependant date range selection limits

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -122,8 +122,8 @@ def get_date_bounds():
             ( min_date, max_date ) = cursor.fetchone()
     connection.close()
     return {
-        "start_time": min_date,
-        "end_time": max_date
+        "start_date": min_date,
+        "end_date": max_date
     }
 
 # test URL /holidays

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -113,7 +113,7 @@ def aggregate_travel_times(start_node, end_node, start_time, end_time, start_dat
     )
 
 # test URL /date-bounds
-@app.route('/date-bounds', methods=['GET'])
+@app.route('/date-range', methods=['GET'])
 def get_date_bounds():
     connection = getConnection()
     with connection:
@@ -122,8 +122,8 @@ def get_date_bounds():
             ( min_date, max_date ) = cursor.fetchone()
     connection.close()
     return {
-        "start_date": min_date,
-        "end_date": max_date
+        "minDate": min_date,
+        "maxDate": max_date
     }
 
 # test URL /holidays

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -7,8 +7,10 @@ import { DataContext } from './Layout'
 export class DateRange extends Factor {
     #startDate
     #endDate
+    #dataContext
     constructor(dataContext){
         super(dataContext)
+        this.#dataContext = dataContext
     }
     get isComplete(){
         return this.#startDate && this.#endDate && this.#startDate < this.#endDate
@@ -71,6 +73,14 @@ export class DateRange extends Factor {
         }
         return dayCount
     }
+    get maxDate(){
+        // default to today if actual max date not known (yet)
+        return this.#dataContext.dateRange.maxDate ?? new Date()
+    }
+    get minDate(){
+        // default to today if actual max date not known (yet)
+        return this.#dataContext.dateRange.minDate ?? new Date('2017-09-01')
+    }
 }
 
 function formatISODate(dt){ // this is waaay too complicated... alas
@@ -79,9 +89,6 @@ function formatISODate(dt){ // this is waaay too complicated... alas
     let day = dt.getUTCDate() // 1 - 31
     return `${year}-${('0'+month).slice(-2)}-${('0'+day).slice(-2)}`
 }
-
-const today = new Date()
-const earliestDataDate = new Date('2017-01-01')
 
 function DateRangeElement({dateRange}){
     const { logActivity } = useContext(DataContext)
@@ -102,8 +109,8 @@ function DateRangeElement({dateRange}){
                     selectRange={true}
                     allowPartialRange={true}
                     onChange={setSelectedRange}
-                    maxDate={today}
-                    minDate={earliestDataDate}
+                    maxDate={dateRange.maxDate}
+                    minDate={dateRange.minDate}
                 />
             </> }
         </div>

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -23,8 +23,10 @@ export class SpatialData {
         fetch(`${domain}/date-range`)
             .then( response => response.json() )
             .then( dates => {
-                this.#dataDateRange.minDate = new Date(dates.minDate)
-                this.#dataDateRange.maxDate = new Date(dates.maxDate)
+                // a raw date will be parsed as UTC time then converted to local
+                // adding the 00:00:00 time component makes it read as local time
+                this.#dataDateRange.minDate = new Date(`${dates.minDate}T00:00:00`)
+                this.#dataDateRange.maxDate = new Date(`${dates.maxDate}T00:00:00`)
             } )
     }
     get corridors(){ return this.#factors.filter( f => f instanceof Corridor ) }

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -12,6 +12,7 @@ export class SpatialData {
     #factors = []
     #queries = new Map() // store/cache for travelTimeQueries, letting them remember their results if any
     #knownHolidays = []
+    #dataDateRange = { minDate: undefined, maxDate: undefined }
     #queue = new PQueue({concurrency: 3})
     constructor(){
         this.#factors.push(new Days(this))
@@ -19,6 +20,12 @@ export class SpatialData {
         fetch(`${domain}/holidays`)
             .then( response => response.json() )
             .then( holidayList => this.#knownHolidays = holidayList )
+        fetch(`${domain}/date-range`)
+            .then( response => response.json() )
+            .then( dates => {
+                this.#dataDateRange.minDate = new Date(dates.minDate)
+                this.#dataDateRange.maxDate = new Date(dates.maxDate)
+            } )
     }
     get corridors(){ return this.#factors.filter( f => f instanceof Corridor ) }
     get timeRanges(){ return this.#factors.filter( f => f instanceof TimeRange ) }
@@ -31,6 +38,7 @@ export class SpatialData {
         return this.corridors.find( cor => cor.isActive )
     }
     get holidays(){ return this.#knownHolidays }
+    get dateRange(){ return this.#dataDateRange }
     createCorridor(){
         let corridor = new Corridor(this)
         this.#factors.push(corridor)


### PR DESCRIPTION
This implements a limit in the UI on the range of dates that can be selected. Can now only select dates actually available in the database.

Closes #68 