### PR TITLE
Select Here map version automatically

### DIFF
--- a/backend/app/get_links.py
+++ b/backend/app/get_links.py
@@ -1,10 +1,11 @@
 import json
 from app.db import getConnection
+from psycopg import sql
 
 links_query = '''
 WITH results as (
     SELECT *
-    FROM here_gis.get_links_btwn_nodes_22_2(
+    FROM here_gis.{routing_function}(
         %(node_start)s,
         %(node_end)s
     ),
@@ -20,21 +21,27 @@ SELECT
     streets.source,
     streets.target
 FROM results
-JOIN here.routing_streets_22_2 AS streets USING ( link_dir )
-JOIN here_gis.streets_att_22_2 AS attr 
+JOIN here.{street_geoms_table} AS streets USING ( link_dir )
+JOIN here_gis.{street_attributes_table} AS attr 
     ON attr.link_id::int = left(link_dir, -1)::int
 ORDER BY seq;
 '''
 
 # returns a json with geometries of links between two nodes
-def get_links(from_node_id, to_node_id):
+def get_links(from_node_id, to_node_id, map_version):
+    parsed_links_query = sql.SQL(links_query).format(
+        routing_function = sql.Identifier(f'get_links_btwn_nodes_{map_version}'),
+        street_geoms_table = sql.Identifier(f'routing_streets_{map_version}'),
+        street_attributes_table = sql.Identifier(f'streets_att_{map_version}')
+    )
     with getConnection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(
-                links_query,
+                parsed_links_query,
                 {
                     "node_start": from_node_id,
-                    "node_end": to_node_id
+                    "node_end": to_node_id,
+                    "map_version": map_version
                 }
             )
 

--- a/backend/app/get_links.py
+++ b/backend/app/get_links.py
@@ -16,7 +16,7 @@ SELECT
     results.link_dir,
     InitCap(attr.st_name) AS st_name,
     results.seq,
-    ST_AsGeoJSON(streets.geom) AS geojson,
+    ST_AsGeoJSON(ST_LineMerge(streets.geom)) AS geojson,
     ST_Length( ST_Transform(streets.geom,2952) ) AS length_m,
     streets.source,
     streets.target
@@ -28,7 +28,7 @@ ORDER BY seq;
 '''
 
 # returns a json with geometries of links between two nodes
-def get_links(from_node_id, to_node_id, map_version):
+def get_links(from_node_id, to_node_id, map_version='23_4'):
     parsed_links_query = sql.SQL(links_query).format(
         routing_function = sql.Identifier(f'get_links_btwn_nodes_{map_version}'),
         street_geoms_table = sql.Identifier(f'routing_streets_{map_version}'),

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -2,6 +2,7 @@
 
 from app.db import getConnection
 from app.get_links import get_links
+from app.selectMapVersion import selectMapVersion
 import numpy
 import math
 import pandas
@@ -26,34 +27,8 @@ def timeFormat(seconds):
         'clock': f'{math.floor(seconds/3600):02d}:{math.floor((seconds/60)%60):02d}:{round(seconds%60):02d}'
     }
 
-def selectMapVersion(start_date, end_date):
-    query = """
-    WITH coverage AS (
-        SELECT
-            street_version,
-            valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
-        FROM here.street_valid_range
-    )
-
-    SELECT
-        street_version,
-        UPPER(overlap) - LOWER(overlap) AS days_covered
-    FROM coverage
-    WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
-    ORDER BY days_covered DESC NULLS LAST
-    """
-    connection = getConnection()
-    with connection:
-        with connection.cursor() as cursor:
-            cursor.execute(query,{'start_date':start_date,'end_date':end_date})
-            (map_version, coverage) = cursor.fetchone()
-    connection.close()
-    return map_version
-
 def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
-
-    map_version = selectMapVersion(start_date, end_date)
 
     holiday_clause = ''
     if not include_holidays:
@@ -78,7 +53,13 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             {holiday_clause}
     '''
 
-    links = get_links(start_node, end_node, map_version)
+    map_version = selectMapVersion(start_date, end_date)
+
+    links = get_links(
+        start_node,
+        end_node,
+        map_version
+    )
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],
@@ -142,7 +123,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 },
             },
             'query': {
-                'corridor': {'links': links},
+                'corridor': {'links': links, 'map_version': map_version},
                 'query_params': query_params
             }
         }
@@ -174,7 +155,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             'observations': [timeFormat(tt) for (dt,tt) in sample]
         },
         'query': {
-            'corridor': {'links': links},
+            'corridor': {'links': links, 'map_version': map_version},
             'query_params': query_params
         }
     }

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -26,8 +26,33 @@ def timeFormat(seconds):
         'clock': f'{math.floor(seconds/3600):02d}:{math.floor((seconds/60)%60):02d}:{round(seconds%60):02d}'
     }
 
+def selectMapVersion(start_date, end_date):
+    query = """
+    WITH coverage AS (
+        SELECT
+            street_version,
+            valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
+        FROM here.street_valid_range
+    )
+
+    SELECT
+        street_version,
+        UPPER(overlap) - LOWER(overlap) AS days_covered
+    FROM coverage
+    WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
+    ORDER BY days_covered DESC NULLS LAST
+    """
+    connection = getConnection()
+    with connection:
+        with connection.cursor() as cursor:
+            cursor.execute(query,{'start_date':start_date,'end_date':end_date})
+            print(cursor.fetchall())
+    connection.close()
+
 def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
+
+    selectMapVersion(start_date, end_date)
 
     holiday_clause = ''
     if not include_holidays:

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -46,13 +46,14 @@ def selectMapVersion(start_date, end_date):
     with connection:
         with connection.cursor() as cursor:
             cursor.execute(query,{'start_date':start_date,'end_date':end_date})
-            print(cursor.fetchall())
+            (map_version, coverage) = cursor.fetchone()
     connection.close()
+    return map_version
 
 def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
 
-    selectMapVersion(start_date, end_date)
+    map_version = selectMapVersion(start_date, end_date)
 
     holiday_clause = ''
     if not include_holidays:
@@ -77,7 +78,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             {holiday_clause}
     '''
 
-    links = get_links(start_node, end_node)
+    links = get_links(start_node, end_node, map_version)
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],

--- a/backend/app/selectMapVersion.py
+++ b/backend/app/selectMapVersion.py
@@ -1,5 +1,8 @@
 from app.db import getConnection
 
+# Selects Here map version to use based on dates in the provided query.
+# however the query also has nodes which may or may not be version-specific
+
 def selectMapVersion(start_date, end_date):
     query = """
     WITH coverage AS (

--- a/backend/app/selectMapVersion.py
+++ b/backend/app/selectMapVersion.py
@@ -1,0 +1,25 @@
+from app.db import getConnection
+
+def selectMapVersion(start_date, end_date):
+    query = """
+    WITH coverage AS (
+        SELECT
+            street_version,
+            valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
+        FROM here.street_valid_range
+    )
+
+    SELECT
+        street_version,
+        UPPER(overlap) - LOWER(overlap) AS days_covered
+    FROM coverage
+    WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
+    ORDER BY days_covered DESC NULLS LAST
+    """
+    connection = getConnection()
+    with connection:
+        with connection.cursor() as cursor:
+            cursor.execute(query,{'start_date':start_date,'end_date':end_date})
+            (map_version, coverage) = cursor.fetchone()
+    connection.close()
+    return map_version


### PR DESCRIPTION
Closes #149

This looks for the Here map version that has the greatest overlap with a query's date range and uses that map version for the query. It does _not_ split a query spanning two map versions into separate parts. That could be a future improvement but isn't implemented here. 

The latest (as of now) map version is hard-coded as the default for selecting nodes and drawing corridors on the map. 