### PR TITLE
Update map version for `node/` endpoint, remove CN constraint

### DIFF
--- a/backend/app/get_node.py
+++ b/backend/app/get_node.py
@@ -5,15 +5,14 @@ from app.db import getConnection
 
 SQL = '''
 SELECT
-    ST_AsGeoJSON(cg_nodes.geom) AS geom,
+    ST_AsGeoJSON(ST_Dump(here_nodes.geom)) AS geom,
     array_agg(DISTINCT InitCap(streets.st_name)) FILTER (WHERE streets.st_name IS NOT NULL) AS street_names
-FROM congestion.network_nodes AS cg_nodes
-JOIN here.routing_nodes_23_4 AS here_nodes USING (node_id)
+FROM here.routing_nodes_23_4 AS here_nodes
 JOIN here_gis.streets_att_23_4 AS streets USING (link_id)
 WHERE node_id = %(node_id)s
 GROUP BY
     node_id,
-    cg_nodes.geom;
+    here_nodes.geom;
 '''
 
 def get_node(node_id):

--- a/backend/app/get_node.py
+++ b/backend/app/get_node.py
@@ -5,13 +5,15 @@ from app.db import getConnection
 
 SQL = '''
 SELECT
-    ST_AsGeoJSON(ST_Dump(here_nodes.geom)) AS geom,
+    ST_AsGeoJSON(
+        ST_GeometryN(here_nodes.geom, 1) -- necessary because currently stored as a multi-point
+    ) AS geom,
     array_agg(DISTINCT InitCap(streets.st_name)) FILTER (WHERE streets.st_name IS NOT NULL) AS street_names
 FROM here.routing_nodes_23_4 AS here_nodes
 JOIN here_gis.streets_att_23_4 AS streets USING (link_id)
-WHERE node_id = %(node_id)s
+WHERE here_nodes.node_id = %(node_id)s
 GROUP BY
-    node_id,
+    here_nodes.node_id,
     here_nodes.geom;
 '''
 

--- a/backend/app/get_node.py
+++ b/backend/app/get_node.py
@@ -8,8 +8,8 @@ SELECT
     ST_AsGeoJSON(cg_nodes.geom) AS geom,
     array_agg(DISTINCT InitCap(streets.st_name)) FILTER (WHERE streets.st_name IS NOT NULL) AS street_names
 FROM congestion.network_nodes AS cg_nodes
-JOIN here.routing_nodes_21_1 AS here_nodes USING (node_id)
-JOIN here_gis.streets_att_21_1 AS streets USING (link_id)
+JOIN here.routing_nodes_23_4 AS here_nodes USING (node_id)
+JOIN here_gis.streets_att_23_4 AS streets USING (link_id)
 WHERE node_id = %(node_id)s
 GROUP BY
     node_id,


### PR DESCRIPTION
This will now return any node in the current map. Should be exactly the same for typical use, but will allow extended analysis for API users and other powerusers.

Resolves #156 