### PR TITLE
Update info about earliest available data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The app can return results in either CSV or JSON format. The fields in either ca
 
 ## Methodology
 
-Data for travel time estimation through the app are sourced from [HERE](https://github.com/CityofToronto/bdit_data-sources/tree/master/here)'s [traffic API](https://developer.here.com/documentation/traffic-api/api-reference.html) and are available back to about 2017. HERE collects data from motor vehicles that report their speed and position to HERE, most likely as a by-poduct of the driver making use of an in-car navigation system connected to the Internet.
+Data for travel time estimation through the app are sourced from [HERE](https://github.com/CityofToronto/bdit_data-sources/tree/master/here)'s [traffic API](https://developer.here.com/documentation/traffic-api/api-reference.html) and are available back to 2017-09-01. HERE collects data from motor vehicles that report their speed and position to HERE, most likely as a by-poduct of the driver making use of an in-car navigation system connected to the Internet.
 
 The number of vehicles within the City of Toronto reporting their position to HERE in this way has been [estimated](./analysis/total-fleet-size.r) to be around 2,000 to 3,000 vehicles during the AM and PM peak periods, with lower numbers in the off hours. While this may seem like a lot, in practice many of these vehicles are on the highways and the coverage of any particular city street within a several hour time window can be very minimal if not nil. For this reason, we are currently restricting travel time estimates to "arterial" streets and highways.  
 

--- a/frontend/src/Sidebar/index.jsx
+++ b/frontend/src/Sidebar/index.jsx
@@ -153,7 +153,7 @@ function Welcome(){
         <h2>Toronto Historic Travel Times</h2>
         <p>
             This application allows you to query averaged motor vehicle travel
-            times across the city, as far back as 2017. Data come from a small
+            times across the city, as far back as 2017-09-01. Data come from a small
             sample of probe vehicles that report their location data 
             to <a href="https://www.here.com/">Here</a>. For more information on
             this application and our methodology 


### PR DESCRIPTION
2017-09-01 is the first day with data. This is now noted in the readme and in the app itself. The app will also not create a query any earlier than that. 

Closes https://github.com/CityofToronto/bdit_tt_request_app/issues/154