### PR TITLE
Return docstrings of backend endpoint functions; also add docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The Travel Time Request App is a simple web application designed to help City st
 This app was originally developed as a [class project by U of T students](https://www.youtube.com/watch?v=y6lnefduogo) in partnership with the City, though it has undergone substantial development by the Data & Analytics Unit since then. 
 
 ## How to use the app
+
+### Via the front-end user-interface 
+
 When you [visit the app](https://trans-bdit.intra.prod-toronto.ca/traveltime-request/), you will be prompted to add/create at least one of each of the following:
 * a corridor, drawn on the map
 * a time range, given in hours of the day, 00 - 23
@@ -21,7 +24,7 @@ Once each factor type has been validly entered it will turn from red to green. O
 
 If you have any trouble using the app, please send an email to Nate Wessel (nate.wessel@toronto.ca) or feel free to open an issue in this repository if you are at all familiar with that process.
 
-## Outputs
+#### Outputs
 
 The app can return results in either CSV or JSON format. The fields in either case are the same:
 
@@ -40,6 +43,11 @@ The app can return results in either CSV or JSON format. The fields in either ca
 | `mean_travel_time_minutes` | The mean travel time in minutes is given as a floating point number rounded to three decimal places. Where insufficient data was available to complete the request, the value will be null. |
 | `mean_travel_time_seconds` | Same as above, but measured in seconds. |
 
+### By querying the back-end API directly
+
+The front-end UI pulls all data from the backend service available at https://trans-bdit.intra.prod-toronto.ca/tt-request-backend/. This API defines several endpoints, all of which return JSON-structured data. Those endpoints are documented at the link above.
+
+Generally, the API returns much more data than is available through the UI and this allows some extended use-cases which are just starting to be documented in the [`analysis/`](./analysis) folder. These may include looking at travel time variability within a given window and conducting statistical comparisons between different time periods.
 
 ## Methodology
 
@@ -59,7 +67,7 @@ We aggregate corridors together spatially as necessary into larger corridors whe
 
 ### Other means of estimating travel times
 
-The City also has [bluetooth sensors](https://github.com/CityofToronto/bdit_data-sources/blob/master/bluetooth/README.md) at some intersections which can be used to get a more reliable measure of travel time. These sensors pick up a much larger proportion of vehicles than the HERE data, making it possible to do a temporally fine-grained analysis. The sensors however are only in a few locations, especially in the downtown core and along the Gardiner and DVP expressways.  
+The City also has [bluetooth sensors](https://github.com/CityofToronto/bdit_data-sources/blob/master/bluetooth/README.md) at some intersections which can be used to get a more reliable measure of travel time. These sensors pick up a much larger proportion of vehicles than the HERE data, making it possible to do a temporally fine-grained analysis. The sensors however are only in a few locations, especially in the downtown core and along the Gardiner and DVP expressways.
 
 ## Development
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -11,10 +11,13 @@ from app.get_links import get_links
 
 @app.route('/')
 def index():
-    """Provides basic documentation about the available resources"""
+    """Provide basic documentation about the available resources.
+    
+    All endpoints return JSON-formatted data.
+    """
     return jsonify({
         'description': 'Travel Time App backend',
-        'endpoints': [
+        'available_endpoints': [
             {
                 'path': str(rule),
                 'docstring': app.view_functions[rule.endpoint].__doc__
@@ -25,8 +28,15 @@ def index():
 # test URL /closest-node/-79.3400/43.6610
 @app.route('/nodes-within/<meters>/<longitude>/<latitude>', methods=['GET'])
 def closest_node(meters, longitude, latitude):
-    """Returns up to 20 nodes within a given radius (in meters) of a point.
-    Nodes are selected from the Congestion Network, i.e. are fairly major intersections."""
+    """Return up to 20 nodes within a given radius (in meters) of a point.
+
+    Nodes are drawn from the Congestion Network, i.e. are fairly major intersections.
+
+    Arguments:
+    meters (numeric): distance around latitude and longitude to search
+    latitude (numeric): latitude of point to search around
+    longitude (numeric): longitude of point to search around
+    """
     try:
         longitude = float(longitude)
         latitude = float(latitude)
@@ -86,15 +96,17 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
 )
 def aggregate_travel_times(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_str):
     """
+    Return averaged travel times given the specified parameters.
+
     Aggregates travel times, returning averaged travel times along the selected corridor during the specified dates and times.
     Also returns some helpful diagnostic data such as the parsed query args, the route identified between the nodes, and some measures of sampling error.
 
     Arguments:
-    start_node, end_node (int): HERE network node_id's
-    start_time, end_time (int): starting (inclusive), ending (exclusive) hours
-    start_date, end_date (YYYY-MM-DD): start (inclusive), end (exclusive) dates
-    include_holidays(str, boolean-ish): 'true' will include holidays, 'false' will exclude them
-    dow_list(str): flattened list of integers, i.e. [1,2,3,4] -> '1234', representing days of week to be included; ISODOW specification
+    start_node, end_node (int): HERE network node_id's from the current Here map version
+    start_time, end_time (int): starting (inclusive), ending (exclusive) hours. May include leading zeros. If the end_time is less than the start_time, the time will wrap midnight.
+    start_date, end_date (str, YYYY-MM-DD): start (inclusive), end (exclusive) dates. end_date must be greater than start_date.
+    include_holidays (str, boolean): 'true' will include holidays, 'false' will exclude them if applicable
+    dow_list (str): flattened list of integers, i.e. [1,2,3,4,5] -> '12345', representing days of week to be included; ISODOW specification
     """
     try:
         start_node = int(start_node)
@@ -148,7 +160,10 @@ def get_date_bounds():
 # test URL /holidays
 @app.route('/holidays', methods=['GET'])
 def get_holidays():
-    "Return dates of all Ontario holidays in ascending order. These should fully cover any available travel time data."
+    """Return dates of all Ontario holidays in ascending order.
+
+    Holidays will fully cover the range of any available travel time data.
+    """
     connection = getConnection()
     query = f"""
     SELECT

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -106,7 +106,7 @@ def aggregate_travel_times(start_node, end_node, start_time, end_time, start_dat
     start_time, end_time (int): starting (inclusive), ending (exclusive) hours. May include leading zeros. If the end_time is less than the start_time, the time will wrap midnight.
     start_date, end_date (str, YYYY-MM-DD): start (inclusive), end (exclusive) dates. end_date must be greater than start_date.
     include_holidays (str, boolean): 'true' will include holidays, 'false' will exclude them if applicable
-    dow_list (str): flattened list of integers, i.e. [1,2,3,4,5] -> '12345', representing days of week to be included; ISODOW specification
+    dow_list (str): concatenated list of integers representing days of week to be included; ISODOW specification. E.g. [6,7] -> '67' for Saturday and Sunday only.
     """
     try:
         start_node = int(start_node)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -13,7 +13,7 @@ from app.get_links import get_links
 def index():
     """Provides basic documentation about the available resources"""
     return jsonify({
-        'description': 'Travel Time App backend root',
+        'description': 'Travel Time App backend',
         'endpoints': [
             {
                 'path': str(rule),
@@ -24,7 +24,9 @@ def index():
 
 # test URL /closest-node/-79.3400/43.6610
 @app.route('/nodes-within/<meters>/<longitude>/<latitude>', methods=['GET'])
-def closest_node(meters,longitude,latitude):
+def closest_node(meters, longitude, latitude):
+    """Returns up to 20 nodes within a given radius (in meters) of a point.
+    Nodes are selected from the Congestion Network, i.e. are fairly major intersections."""
     try:
         longitude = float(longitude)
         latitude = float(latitude)
@@ -36,6 +38,8 @@ def closest_node(meters,longitude,latitude):
 # test URL /node/30357505
 @app.route('/node/<node_id>', methods=['GET'])
 def node(node_id):
+    """Returns information about a given node in the Here street network.
+    This uses the latest map version and may not recognize an older node_id."""
     try:
         node_id = int(node_id)
     except:
@@ -46,7 +50,8 @@ def node(node_id):
 #shell function - outputs json for use on frontend
 @app.route('/link-nodes/<from_node_id>/<to_node_id>', methods=['GET'])
 def get_links_between_two_nodes(from_node_id, to_node_id):
-    """Returns links of the shortest path between two nodes on the HERE network"""
+    """Returns links of the shortest path between two nodes on the HERE network,
+    including link_dir IDs, link geometries, and lengths in meters."""
     try:
         from_node_id = int(from_node_id)
         to_node_id = int(to_node_id)
@@ -79,12 +84,18 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
     '/aggregate-travel-times/<start_node>/<end_node>/<start_time>/<end_time>/<start_date>/<end_date>/<include_holidays>/<dow_str>',
     methods=['GET']
 )
-# - start_node, end_node (int): the congestion network / HERE node_id's
-# - start_time, end_time (int): starting (inclusive), ending (exclusive) hours of aggregation
-# - start_date, end_date (YYYY-MM-DD): start (inclusive), end (exclusive) date of aggregation
-# - include_holidays(str, boolean-ish): 'true' will include holidays
-# - dow_list(str): flattened list of integers, i.e. [1,2,3,4] -> '1234', representing days of week to be included (ISODOW)
 def aggregate_travel_times(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_str):
+    """
+    Aggregates travel times, returning averaged travel times along the selected corridor during the specified dates and times.
+    Also returns some helpful diagnostic data such as the parsed query args, the route identified between the nodes, and some measures of sampling error.
+
+    Arguments:
+    start_node, end_node (int): HERE network node_id's
+    start_time, end_time (int): starting (inclusive), ending (exclusive) hours
+    start_date, end_date (YYYY-MM-DD): start (inclusive), end (exclusive) dates
+    include_holidays(str, boolean-ish): 'true' will include holidays, 'false' will exclude them
+    dow_list(str): flattened list of integers, i.e. [1,2,3,4] -> '1234', representing days of week to be included; ISODOW specification
+    """
     try:
         start_node = int(start_node)
         end_node = int(end_node)
@@ -122,6 +133,7 @@ def aggregate_travel_times(start_node, end_node, start_time, end_time, start_dat
 # test URL /date-bounds
 @app.route('/date-range', methods=['GET'])
 def get_date_bounds():
+    """Returns the dates of the earliest and latest available travel time data."""
     connection = getConnection()
     with connection:
         with connection.cursor() as cursor:
@@ -136,7 +148,7 @@ def get_date_bounds():
 # test URL /holidays
 @app.route('/holidays', methods=['GET'])
 def get_holidays():
-    "Return dates of all known holidays in ascending order"
+    "Return dates of all Ontario holidays in ascending order. These should fully cover any available travel time data."
     connection = getConnection()
     query = f"""
     SELECT

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -33,9 +33,9 @@ def closest_node(meters, longitude, latitude):
     Nodes are drawn from the Congestion Network, i.e. are fairly major intersections.
 
     Arguments:
-    meters (numeric): distance around latitude and longitude to search
-    latitude (numeric): latitude of point to search around
-    longitude (numeric): longitude of point to search around
+    meters (float): distance around latitude and longitude to search
+    latitude (float): latitude of point to search around
+    longitude (float): longitude of point to search around
     """
     try:
         longitude = float(longitude)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -101,6 +101,7 @@ def aggregate_travel_times(start_node, end_node, start_time, end_time, start_dat
     """
     Return averaged travel times given the specified parameters.
 
+    This function just parses arguments and otherwise wraps around `get_travel_times` which does the actual work...
     Aggregates travel times, returning averaged travel times along the selected corridor during the specified dates and times.
     Also returns some helpful diagnostic data such as the parsed query args, the route identified between the nodes, and some measures of sampling error.
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -11,9 +11,15 @@ from app.get_links import get_links
 
 @app.route('/')
 def index():
+    """Provides basic documentation about the available resources"""
     return jsonify({
         'description': 'Travel Time App backend root',
-        'endpoints': [str(rule) for rule in app.url_map.iter_rules()]
+        'endpoints': [
+            {
+                'path': str(rule),
+                'docstring': app.view_functions[rule.endpoint].__doc__
+            } for rule in app.url_map.iter_rules()
+        ]
     })
 
 # test URL /closest-node/-79.3400/43.6610

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -49,7 +49,12 @@ def closest_node(meters, longitude, latitude):
 @app.route('/node/<node_id>', methods=['GET'])
 def node(node_id):
     """Returns information about a given node in the Here street network.
-    This uses the latest map version and may not recognize an older node_id."""
+
+    This uses the latest map version and may not recognize an older node_id.
+    
+    arguments:
+    node_id (int): identifier of the node in the latest Here map version
+    """
     try:
         node_id = int(node_id)
     except:

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -60,8 +60,11 @@ def node(node_id):
 #shell function - outputs json for use on frontend
 @app.route('/link-nodes/<from_node_id>/<to_node_id>', methods=['GET'])
 def get_links_between_two_nodes(from_node_id, to_node_id):
-    """Returns links of the shortest path between two nodes on the HERE network,
-    including link_dir IDs, link geometries, and lengths in meters."""
+    """Returns links of the shortest path between any two nodes on the HERE network.
+    
+    Results include link_dir IDs, link geometries, and lengths in meters.
+    Routing is done in PostgreSQL using `here_gis.get_links_btwn_nodes_{map_version}`
+    """
     try:
         from_node_id = int(from_node_id)
         to_node_id = int(to_node_id)


### PR DESCRIPTION
Closes #114

With much help from [this gist](https://gist.github.com/cybertoast/6499708), this PR adds function docstrings to the existing API's [list of it's own endpoints](https://trans-bdit.intra.prod-toronto.ca/tt-request-backend/). And, now that they're more exposed, I've finally felt compelled to actually add docstrings to all the functions.