### PR TITLE
Rethink how routing between nodes is done

### DIFF
--- a/backend/app/get_centreline_links.py
+++ b/backend/app/get_centreline_links.py
@@ -1,0 +1,49 @@
+import json
+from app.db import getConnection
+
+links_query = '''
+WITH centreline_path AS (
+    SELECT unnest(links)::int AS centreline_id
+    FROM gis_core.get_centreline_btwn_intersections(
+        %(from_node_id)s,
+        %(to_node_id)s
+    )
+)
+
+SELECT
+    centreline_id,
+    linear_name_full_legal AS st_name,
+    from_intersection_id,
+    to_intersection_id,
+    ST_AsGeoJSON(geom) AS geojson,
+    ST_length(ST_Transform(geom, 2952)) AS length_m
+FROM centreline_path
+JOIN gis_core.centreline_latest USING (centreline_id)
+'''
+
+# returns a json with geometries of links between two nodes
+def get_centreline_links(from_node_id, to_node_id, map_version='23_4'):
+    with getConnection() as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                links_query,
+                {
+                    "from_node_id": from_node_id,
+                    "to_node_id": to_node_id
+                }
+            )
+
+            links = [
+                {
+                    'centreline_id': centreline_id,
+                    'name': st_name,
+                    #'sequence': seq,
+                    'geometry': json.loads(geojson),
+                    'length_m': length_m,
+                    'source': source,
+                    'target': target
+                } for centreline_id, st_name, geojson, length_m, source, target in cursor.fetchall()
+            ]
+
+    connection.close()
+    return links

--- a/backend/app/get_centreline_links.py
+++ b/backend/app/get_centreline_links.py
@@ -13,10 +13,10 @@ WITH centreline_path AS (
 SELECT
     centreline_id,
     linear_name_full_legal AS st_name,
-    from_intersection_id,
-    to_intersection_id,
     ST_AsGeoJSON(geom) AS geojson,
-    ST_length(ST_Transform(geom, 2952)) AS length_m
+    ST_length(ST_Transform(geom, 2952)) AS length_m,
+    from_intersection_id,
+    to_intersection_id
 FROM centreline_path
 JOIN gis_core.centreline_latest USING (centreline_id)
 '''

--- a/backend/app/get_here_links.py
+++ b/backend/app/get_here_links.py
@@ -28,7 +28,7 @@ ORDER BY seq;
 '''
 
 # returns a json with geometries of links between two nodes
-def get_links(from_node_id, to_node_id, map_version='23_4'):
+def get_here_links(from_node_id, to_node_id, map_version='23_4'):
     parsed_links_query = sql.SQL(links_query).format(
         routing_function = sql.Identifier(f'get_links_btwn_nodes_{map_version}'),
         street_geoms_table = sql.Identifier(f'routing_streets_{map_version}'),

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -1,7 +1,7 @@
 """Function for returning data from the aggregate-travel-times/ endpoint"""
 
 from app.db import getConnection
-from app.get_links import get_links
+from app.get_here_links import get_here_links
 from app.selectMapVersion import selectMapVersion
 import numpy
 import math
@@ -60,7 +60,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
 
     map_version = selectMapVersion(start_date, end_date)
 
-    links = get_links(
+    links = get_here_links(
         start_node,
         end_node,
         map_version

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -71,10 +71,20 @@ def node(node_id):
 #shell function - outputs json for use on frontend
 @app.route('/link-nodes/<network>/<from_node_id>/<to_node_id>')
 def get_here_links_between_two_nodes(network, from_node_id, to_node_id):
-    """Returns links of the shortest path between any two nodes on the HERE network.
-    
-    Results include link_dir IDs, link geometries, and lengths in meters.
+    """Returns a list of links/edges defining the shortest path between two nodes.
+
+    Each link has 
+        * an ID (centreline_id or linkdir, depending on the reference network)
+        * a geometry, GeoJSON style
+        * a length in meters
+        * the name of the street
+        * source and target nodes in the reference network
     Routing is done in PostgreSQL using `here_gis.get_links_btwn_nodes_{map_version}`
+
+    arguments:
+    network (str): reference network to use; either 'here' or 'centreline'
+    from_node_id (int): origin node ID on the reference network
+    to_node_id (int): destination node ID on the reference network
     """
     try:
         from_node_id = int(from_node_id)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -84,23 +84,18 @@ def get_here_links_between_two_nodes(network, from_node_id, to_node_id):
 
     if from_node_id == to_node_id:
         return jsonify({'error': "Source node can not be the same as target node."}), 400
+
     if network == 'here':
         links = get_here_links(from_node_id, to_node_id)
     elif network == 'centreline':
         links = get_centreline_links(from_node_id, to_node_id)
     else:
         return jsonify({'error': "Network should be one of ['here','centreline']"}), 400
+
     return jsonify({
         "source": from_node_id, 
         "target": to_node_id,
-        "links": links,
-        # the following three fields are for compatibility and should eventually be removed
-        "path_name": "",
-        #"link_dirs": [ link['link_dir'] for link in links ],
-        "geometry": {
-            "type": "MultiLineString",
-            "coordinates": [ link['geometry']['coordinates'] for link in links ]
-        }
+        "links": links
     })
 
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -7,6 +7,7 @@ from app.get_closest_nodes import get_nodes_within
 from app.get_node import get_node
 from app.get_travel_time import get_travel_time
 from app.get_here_links import get_here_links
+from app.get_centreline_links import get_centreline_links
 
 @app.route('/')
 def index():
@@ -68,8 +69,8 @@ def node(node_id):
 
 # test URL /link-nodes/here/30421154/30421153
 #shell function - outputs json for use on frontend
-@app.route('/link-nodes/here/<from_node_id>/<to_node_id>')
-def get_here_links_between_two_nodes(from_node_id, to_node_id):
+@app.route('/link-nodes/<network>/<from_node_id>/<to_node_id>')
+def get_here_links_between_two_nodes(network, from_node_id, to_node_id):
     """Returns links of the shortest path between any two nodes on the HERE network.
     
     Results include link_dir IDs, link geometries, and lengths in meters.
@@ -83,16 +84,19 @@ def get_here_links_between_two_nodes(from_node_id, to_node_id):
 
     if from_node_id == to_node_id:
         return jsonify({'error': "Source node can not be the same as target node."}), 400
-
-    links = get_here_links(from_node_id, to_node_id)
-
+    if network == 'here':
+        links = get_here_links(from_node_id, to_node_id)
+    elif network == 'centreline':
+        links = get_centreline_links(from_node_id, to_node_id)
+    else:
+        return jsonify({'error': "Network should be one of ['here','centreline']"}), 400
     return jsonify({
         "source": from_node_id, 
         "target": to_node_id,
         "links": links,
         # the following three fields are for compatibility and should eventually be removed
         "path_name": "",
-        "link_dirs": [ link['link_dir'] for link in links ],
+        #"link_dirs": [ link['link_dir'] for link in links ],
         "geometry": {
             "type": "MultiLineString",
             "coordinates": [ link['geometry']['coordinates'] for link in links ]

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -6,8 +6,7 @@ from app.db import getConnection
 from app.get_closest_nodes import get_nodes_within
 from app.get_node import get_node
 from app.get_travel_time import get_travel_time
-
-from app.get_links import get_links
+from app.get_here_links import get_here_links
 
 @app.route('/')
 def index():
@@ -67,10 +66,10 @@ def node(node_id):
 
     return jsonify(get_node(node_id, doConflation))
 
-# test URL /link-nodes/30421154/30421153
+# test URL /link-nodes/here/30421154/30421153
 #shell function - outputs json for use on frontend
-@app.route('/link-nodes/<from_node_id>/<to_node_id>', methods=['GET'])
-def get_links_between_two_nodes(from_node_id, to_node_id):
+@app.route('/link-nodes/here/<from_node_id>/<to_node_id>')
+def get_here_links_between_two_nodes(from_node_id, to_node_id):
     """Returns links of the shortest path between any two nodes on the HERE network.
     
     Results include link_dir IDs, link geometries, and lengths in meters.
@@ -85,7 +84,7 @@ def get_links_between_two_nodes(from_node_id, to_node_id):
     if from_node_id == to_node_id:
         return jsonify({'error': "Source node can not be the same as target node."}), 400
 
-    links = get_links(from_node_id, to_node_id)
+    links = get_here_links(from_node_id, to_node_id)
 
     return jsonify({
         "source": from_node_id, 

--- a/frontend/src/segment.js
+++ b/frontend/src/segment.js
@@ -15,7 +15,7 @@ export class Segment {
     get fromIntersection(){ return this.#fromIntersection }
     get toIntersection(){ return this.#toIntersection }
     fetchLinks(){
-        return fetch(`${domain}/link-nodes/${this.#fromIntersection.id}/${this.toIntersection.id}`)
+        return fetch(`${domain}/link-nodes/here/${this.#fromIntersection.id}/${this.toIntersection.id}`)
             .then( resp => resp.json() )
             .then( ({links}) => {
                 this.#links = links


### PR DESCRIPTION
The app strictly uses the Here network, but it's helpful for other purposes to generalize this and allow a compatible means of routing on the centreline network as well. 

Eventually, the app may pull in data from other City sources, which is generally located on the centreline network.

This work also trims some long-deprecated fields from the link-nodes output. 