### PR TITLE
Add API route endpoint for checking current deployed version

### DIFF
--- a/backend/app/getGitHash.py
+++ b/backend/app/getGitHash.py
@@ -1,0 +1,4 @@
+from subprocess import check_output
+
+def getGitHash():
+    return check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -27,9 +27,9 @@ def index():
 
 @app.route('/version')
 def version():
-    """Return the Git hash of the application"""
+    """Return the Git hash of the current application HEAD"""
     return jsonify({
-        'git-hash': getGitHash()
+        'git-HEAD': getGitHash()
     })
 
 # test URL /closest-node/-79.3400/43.6610

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,5 +1,4 @@
 import json, re
-from subprocess import check_output
 from datetime import datetime
 from flask import jsonify, request
 from app import app
@@ -9,7 +8,7 @@ from app.get_node import get_node
 from app.get_travel_time import get_travel_time
 from app.get_here_links import get_here_links
 from app.get_centreline_links import get_centreline_links
-
+from app.getGitHash import getGitHash
 @app.route('/')
 def index():
     """Provide basic documentation about the available resources.
@@ -27,10 +26,10 @@ def index():
     })
 
 @app.route('/version')
-def getGitHash():
+def version():
     """Return the Git hash of the application"""
     return jsonify({
-        'git-hash': check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+        'git-hash': getGitHash()
     })
 
 # test URL /closest-node/-79.3400/43.6610

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,4 +1,5 @@
 import json, re
+from subprocess import check_output
 from datetime import datetime
 from flask import jsonify, request
 from app import app
@@ -23,6 +24,13 @@ def index():
                 'docstring': app.view_functions[rule.endpoint].__doc__
             } for rule in app.url_map.iter_rules()
         ]
+    })
+
+@app.route('/version')
+def getGitHash():
+    """Return the Git hash of the application"""
+    return jsonify({
+        'git-hash': check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
     })
 
 # test URL /closest-node/-79.3400/43.6610


### PR DESCRIPTION
This will fail silently if the repo is out of sync with what is actually deployed. This should be a rare situation though. 