### PR TITLE
Default to *current* map version

### DIFF
--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -2,7 +2,7 @@
 
 from app.db import getConnection
 from app.get_here_links import get_here_links
-from app.selectMapVersion import selectMapVersion
+from app.hereMapVersion import hereMapVersion
 from traveltimetools.utils import timeFormats
 import numpy
 import math

--- a/backend/app/hereMapVersion.py
+++ b/backend/app/hereMapVersion.py
@@ -23,7 +23,7 @@ FROM here.street_valid_range
 WHERE valid_range @> NOW()::date;
 """
 
-def selectMapVersion(start_date=None, end_date=None):
+def hereMapVersion(start_date=None, end_date=None):
     connection = getConnection()
     with connection:
         with connection.cursor() as cursor:

--- a/backend/app/selectMapVersion.py
+++ b/backend/app/selectMapVersion.py
@@ -3,26 +3,35 @@ from app.db import getConnection
 # Selects Here map version to use based on dates in the provided query.
 # however the query also has nodes which may or may not be version-specific
 
-def selectMapVersion(start_date, end_date):
-    query = """
-    WITH coverage AS (
-        SELECT
-            street_version,
-            valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
-        FROM here.street_valid_range
-    )
-
+rangeQuery = """
+WITH coverage AS (
     SELECT
         street_version,
-        UPPER(overlap) - LOWER(overlap) AS days_covered
-    FROM coverage
-    WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
-    ORDER BY days_covered DESC NULLS LAST
-    """
+        valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
+    FROM here.street_valid_range
+)
+
+SELECT street_version
+FROM coverage
+WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
+ORDER BY UPPER(overlap) - LOWER(overlap) DESC NULLS LAST;
+"""
+
+nowQuery = """
+SELECT street_version
+FROM here.street_valid_range
+WHERE valid_range @> NOW()::date;
+"""
+
+def selectMapVersion(start_date=None, end_date=None):
     connection = getConnection()
     with connection:
         with connection.cursor() as cursor:
-            cursor.execute(query,{'start_date':start_date,'end_date':end_date})
-            (map_version, coverage) = cursor.fetchone()
+            # a daterange has been provided
+            cursor.execute(
+                rangeQuery if start_date and end_date else nowQuery,
+                {'start_date':start_date,'end_date':end_date}
+            )
+            (map_version) = cursor.fetchone()
     connection.close()
     return map_version


### PR DESCRIPTION
There are several places where we have the Here map version hardcoded in queries. Ideally, these should dynamically select the current map version by default. 

Work in progress.

I'm currently somewhat concerned this will impact performance if we don't have a smarter way of sharing connections among the queries needed to resolve a single API call. It's just one more connection at the moment. 