### PR TITLE
Do not merge: Add min and max observed travel times

### DIFF
--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -80,6 +80,15 @@ export class TravelTimeQuery {
         record.set('hoursInRange', this.hoursInRange)
         record.set('mean_travel_time_minutes', this.#results?.travel_time?.minutes)
         record.set('mean_travel_time_seconds', this.#results?.travel_time?.seconds)
+        // minimum and maximum travel time observations
+        record.set(
+            'max_travel_time_seconds',
+            Math.max(...this.#results.observations.map(o => o.seconds))
+        )
+        record.set(
+            'min_travel_time_seconds',
+            Math.min(...this.#results.observations.map(o => o.seconds))
+        )
         // turning these off in the frontend until they're ready for production
         //record.set('moe_lower_p95', this.#results?.confidence?.intervals?.['p=0.95']?.lower?.seconds)
         //record.set('moe_upper_p95', this.#results?.confidence?.intervals?.['p=0.95']?.upper?.seconds)


### PR DESCRIPTION
This quick change was in support of a data request. It should not be merged but was committed to document the process used. 