### PR TITLE
Use connection pooling

### DIFF
--- a/backend/app/dates.py
+++ b/backend/app/dates.py
@@ -1,5 +1,5 @@
 from time import time
-from app.db import getConnection
+from app.db import pool
 
 # This is a very efficient query of a large table (indexes only, really),
 # but because it takes some time, including just connecting, and because it
@@ -15,12 +15,10 @@ cache = {
 def currentDateBounds():
     if time() - cache['time'] < 600: # 600 seconds = 10 minutes
         return cache['results']
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute('SELECT MIN(dt)::text, MAX(dt)::text FROM here.ta;')
             ( min_date, max_date ) = cursor.fetchone()
-    connection.close()
     results = {
         "minDate": min_date,
         "maxDate": max_date

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -6,17 +6,15 @@ from psycopg_pool import ConnectionPool
 
 load_dotenv()
 
-kwargs = {
-    'host': os.environ['DB_HOST'],
-    'dbname': os.environ['DB_NAME'],
-    'user': os.environ['DB_USER'],
-    'password': os.environ['DB_USER_PASSWORD']
-}
-
-pool = ConnectionPool(kwargs=kwargs,min_size=1,max_size=5,open=True)
+pool = ConnectionPool(
+    kwargs={
+        'host': os.environ['DB_HOST'],
+        'dbname': os.environ['DB_NAME'],
+        'user': os.environ['DB_USER'],
+        'password': os.environ['DB_USER_PASSWORD']
+    },
+    min_size=1,
+    max_size=5,
+    open=True
+)
 pool.wait()
-
-def getConnection():
-    with pool.connection() as conn:
-        #print(conn.execute('SELECT * FROM here.ta LIMIT 1'))
-        yield conn

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -2,14 +2,21 @@
 
 import os
 from dotenv import load_dotenv
-from psycopg import connect
+from psycopg_pool import ConnectionPool
 
 load_dotenv()
 
+kwargs = {
+    'host': os.environ['DB_HOST'],
+    'dbname': os.environ['DB_NAME'],
+    'user': os.environ['DB_USER'],
+    'password': os.environ['DB_USER_PASSWORD']
+}
+
+pool = ConnectionPool(kwargs=kwargs,min_size=1,max_size=5,open=True)
+pool.wait()
+
 def getConnection():
-    return connect(
-        host = os.environ['DB_HOST'],
-        dbname = os.environ['DB_NAME'],
-        user = os.environ['DB_USER'],
-        password = os.environ['DB_USER_PASSWORD'],
-    )
+    with pool.connection() as conn:
+        #print(conn.execute('SELECT * FROM here.ta LIMIT 1'))
+        yield conn

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -1,6 +1,6 @@
 """Function for returning data from the aggregate-travel-times/ endpoint"""
 
-from app.db import getConnection
+from app.db import pool
 from app.links.here import get_here_links
 from app.selectMapVersion import selectMapVersion
 from traveltimetools.utils import timeFormats
@@ -28,8 +28,7 @@ def checkCache(uri):
         FROM nwessel.cached_travel_times
         WHERE uri_string = %(uri)s AND commit_hash = %(hash)s
     '''
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             try:
                 cursor.execute(query, {'uri': uri, 'hash': getGitHash()})
@@ -43,8 +42,7 @@ def cacheAndReturn(obj,uri):
         INSERT INTO nwessel.cached_travel_times (uri_string, commit_hash, results)
         VALUES (%(uri)s, %(hash)s, %(results)s)
     '''
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             try:
                 cursor.execute(query, {'uri': uri, 'hash': getGitHash(), 'results': json.dumps(obj)})
@@ -114,15 +112,13 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         "dow_list": dow_list
     }
 
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(query, query_params)
             link_speeds_df = pandas.DataFrame(
                 cursor.fetchall(),
                 columns=['link_dir','dt','hr','speed']
             ).set_index('link_dir')
-    connection.close()
 
     # join previously queried link lengths
     link_speeds_df = link_speeds_df.join(links_df)

--- a/backend/app/links/centreline.py
+++ b/backend/app/links/centreline.py
@@ -1,5 +1,5 @@
 import json
-from app.db import getConnection
+from app.db import pool
 
 links_query = '''
 WITH centreline_path AS (
@@ -23,7 +23,7 @@ JOIN gis_core.centreline_latest USING (centreline_id)
 
 # returns a json with geometries of links between two nodes
 def get_centreline_links(from_node_id, to_node_id):
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 links_query,
@@ -44,6 +44,4 @@ def get_centreline_links(from_node_id, to_node_id):
                     'target': target
                 } for centreline_id, st_name, geojson, length_m, source, target in cursor.fetchall()
             ]
-
-    connection.close()
     return links

--- a/backend/app/links/here.py
+++ b/backend/app/links/here.py
@@ -1,5 +1,5 @@
 import json
-from app.db import getConnection
+from app.db import pool
 from psycopg import sql
 from app.selectMapVersion import selectMapVersion
 from app.getGitHash import getGitHash
@@ -16,8 +16,7 @@ VALUES (%(uri)s, %(hash)s, %(results)s)
 '''
 
 def cacheAndReturn(obj,uri):
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             try:
                 cursor.execute(
@@ -28,8 +27,7 @@ def cacheAndReturn(obj,uri):
                 return obj
 
 def checkCache(uri):
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             try: # try keeps this loosely coupled - no strict dependency
                 cursor.execute(
@@ -82,7 +80,7 @@ def get_here_links(from_node_id, to_node_id, map_version='??_?'):
         street_geoms_table = sql.Identifier(f'routing_streets_{map_version}'),
         street_attributes_table = sql.Identifier(f'streets_att_{map_version}')
     )
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 parsed_links_query,
@@ -104,6 +102,4 @@ def get_here_links(from_node_id, to_node_id, map_version='??_?'):
                     'target': target
                 } for link_dir, st_name, seq, geojson, length_m, source, target in cursor.fetchall()
             ]
-
-    connection.close()
     return cacheAndReturn(links,URI)

--- a/backend/app/nodes/byID/centreline.py
+++ b/backend/app/nodes/byID/centreline.py
@@ -1,5 +1,5 @@
 import json
-from app.db import getConnection
+from app.db import pool
 from app.nodes.conflation import add_conflated_nodes
 
 SQL = '''
@@ -14,7 +14,7 @@ GROUP BY geom;
 def get_centreline_node(node_id, doConflation=False):
     """fetch a specific centreline node by it's ID"""
     node = {}
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(SQL, {"node_id": node_id})
             if cursor.rowcount != 1:
@@ -26,7 +26,6 @@ def get_centreline_node(node_id, doConflation=False):
                 'street_names': street_names,
                 'geometry': json.loads(geojson)
             }
-    connection.close()
     if doConflation:
         node = add_conflated_nodes(node)
     return node

--- a/backend/app/nodes/byID/here.py
+++ b/backend/app/nodes/byID/here.py
@@ -2,7 +2,7 @@
 
 import json
 from psycopg import sql
-from app.db import getConnection
+from app.db import pool
 from app.nodes.conflation import add_conflated_nodes
 from app.selectMapVersion import selectMapVersion
 
@@ -30,7 +30,7 @@ def get_here_node(node_id, conflate_with_centreline=False):
         street_attributes_table = sql.Identifier(f'streets_att_{map_version}')
     )
     node = {}
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(versioned_node_query, {"node_id": node_id})
             if cursor.rowcount != 1:
@@ -43,7 +43,6 @@ def get_here_node(node_id, conflate_with_centreline=False):
                 'street_names': street_names,
                 'geometry': json.loads(geojson)
             }
-    connection.close()
     if conflate_with_centreline:
         node = add_conflated_nodes(node)
     return node

--- a/backend/app/nodes/byID/px.py
+++ b/backend/app/nodes/byID/px.py
@@ -1,5 +1,5 @@
 import json
-from app.db import getConnection
+from app.db import pool
 
 SQL = '''
 SELECT
@@ -20,7 +20,7 @@ WHERE tts."centrelineId" = %(centreline_id)s;
 
 def get_px_node(centreline_id):
     node = {}
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(SQL, {"centreline_id": centreline_id})
             if cursor.rowcount != 1:

--- a/backend/app/nodes/nearby/centreline.py
+++ b/backend/app/nodes/nearby/centreline.py
@@ -1,4 +1,4 @@
-from app.db import getConnection
+from app.db import pool
 from json import loads as loadJSON
 
 SQL = '''
@@ -33,7 +33,7 @@ def get_nearest_centreline_node(longitude, latitude):
     latitude (float): latitude of the point to search around
     """
     node = {}
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(SQL, {'longitude': longitude, 'latitude': latitude})
             centreline_id, geojson, distance, street_names = cursor.fetchone()
@@ -45,6 +45,5 @@ def get_nearest_centreline_node(longitude, latitude):
                 'geometry': loadJSON(geojson),
                 'distance': distance
             }
-    connection.close()
     return node
 

--- a/backend/app/nodes/nearby/here.py
+++ b/backend/app/nodes/nearby/here.py
@@ -1,6 +1,6 @@
 import json
 from psycopg import sql
-from app.db import getConnection
+from app.db import pool
 from app.selectMapVersion import selectMapVersion
 
 nodes_query = '''
@@ -31,7 +31,7 @@ def get_here_nodes_within(meters, longitude, latitude, limit=20):
         street_attributes_table = sql.Identifier(f'streets_att_{map_version}')
     )
 
-    with getConnection() as connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(
                 versioned_nodes_query,
@@ -51,5 +51,4 @@ def get_here_nodes_within(meters, longitude, latitude, limit=20):
                         'street_names': street_names,
                         'geometry': json.loads(geojson)
                     } )
-    connection.close()
     return candidate_nodes

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -2,7 +2,7 @@ import json, re
 from datetime import datetime
 from flask import jsonify, request
 from app import app
-from app.db import getConnection
+from app.db import pool
 from app.nodes.nearby.here import get_here_nodes_within
 from app.nodes.byID.here import get_here_node
 from app.nodes.byID.centreline import get_centreline_node
@@ -195,7 +195,6 @@ def get_holidays():
 
     Holidays will fully cover the range of any available travel time data.
     """
-    connection = getConnection()
     query = f"""
     SELECT
         dt::text,
@@ -205,7 +204,7 @@ def get_holidays():
     WHERE dt >= %(minDate)s AND dt < %(maxDate)s
     ORDER BY dt;
     """
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(query, get_date_bounds())
             dates = [
@@ -215,7 +214,6 @@ def get_holidays():
                     'name': nm
                 } for (dt, dow, nm) in cursor.fetchall()
             ]
-    connection.close()
     return dates
 
 # test URL /raw-data/2025-01-01?link_dirs=29588695T,29588707T
@@ -235,7 +233,6 @@ def raw_data(date):
     link_dirs = re.findall(r'(\d+T|\d+F)',link_dir_csv)
     if not len(link_dirs) >= 1:
         return { 'error': 'Please supply valid link_dirs (\d+T|\d+F)' } 
-    connection = getConnection()
     query = f"""
     SELECT
         link_dir,
@@ -247,7 +244,7 @@ def raw_data(date):
         AND link_dir = ANY(%(link_dirs)s)
     LIMIT 1000;
     """
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             cursor.execute(query, { 'date': date, 'link_dirs': link_dirs })
             records = [
@@ -257,5 +254,4 @@ def raw_data(date):
                     'sample_size': sample_size
                 } for (link_dir, tod, sample_size) in cursor.fetchall()
             ]
-    connection.close()
     return records

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -12,6 +12,7 @@ from app.links.centreline import get_centreline_links
 from app.getGitHash import getGitHash
 from app.dates import currentDateBounds
 
+# test URL: /
 @app.route('/')
 def index():
     """Provide basic documentation about the available resources.
@@ -28,6 +29,7 @@ def index():
         ]
     })
 
+# test URL: /version
 @app.route('/version')
 def version():
     """Return the Git hash of the current application HEAD"""
@@ -56,6 +58,7 @@ def closest_node(meters, longitude, latitude):
     return jsonify(get_here_nodes_within(meters,longitude,latitude))
 
 # test URL /node/here/30357505
+#          /node/centreline/13460901
 @app.route('/node/<node_id>', endpoint='generic') # will be deprecated
 @app.route('/node/here/<node_id>', endpoint='here-nodes')
 @app.route('/node/centreline/<node_id>', endpoint='centreline-nodes')
@@ -85,7 +88,7 @@ def get_node(node_id):
     return jsonify(node if node else {'error': 'node not found'})
 
 # test URL /link-nodes/here/30421154/30421153
-#shell function - outputs json for use on frontend
+#          /link-nodes/centreline/13460901/13461051
 @app.route('/link-nodes/here/<from_node_id>/<to_node_id>', endpoint='here-links')
 @app.route('/link-nodes/centreline/<from_node_id>/<to_node_id>', endpoint='centreline-links')
 def get_here_links_between_two_nodes(from_node_id, to_node_id):
@@ -182,7 +185,7 @@ def aggregate_travel_times(start_node, end_node, start_time, end_time, start_dat
         )
     )
 
-# test URL /date-bounds
+# test URL /date-range
 @app.route('/date-range')
 def get_date_bounds():
     """Returns the dates of the earliest and latest available travel time data."""

--- a/backend/app/selectMapVersion.py
+++ b/backend/app/selectMapVersion.py
@@ -1,4 +1,4 @@
-from app.db import getConnection
+from app.db import pool
 from app.dates import maxDate
 
 # Selects Here map version to use based on a date range for the travel time
@@ -25,8 +25,7 @@ WHERE valid_range @> %(maxDate)s::date;
 """
 
 def selectMapVersion(start_date='????-??-??', end_date='????-??-??'):
-    connection = getConnection()
-    with connection:
+    with pool.connection() as connection:
         with connection.cursor() as cursor:
             if start_date == '????-??-??':
                 cursor.execute(query_for_latest_date, {'maxDate': maxDate()})
@@ -36,5 +35,4 @@ def selectMapVersion(start_date='????-??-??', end_date='????-??-??'):
                     {'start_date':start_date,'end_date':end_date}
                 )
             (map_version,) = cursor.fetchone()
-    connection.close()
     return map_version

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ gunicorn==20.1.0
 packaging==20.7
 pandas==2.2.2
 psycopg==3.1.18
+psycopg_pool=3.2.6
 python-dotenv==0.15.0
 numpy==1.26.0
 git+ssh://git@github.com/Toronto-Big-Data-Innovation-Team/traveltimetools.git@v1.0.0


### PR DESCRIPTION
Resolves #200. 

This replaces many ad-hoc connections for each function with a connection pool approach where connections to the database (up to 5 of them) can be maintained and passed between workers without needing to open and close for each operation. 

This should reduce some overhead and speed things up a little bit. 

Also, instead of having to explicitly close connections (which wasn't even being done consistently), this uses context managers throughout. 