### PR TITLE
Properly handle most travel time requests that span map version changes

### DIFF
--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -204,7 +204,10 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 },
             },
             'query': {
-                'corridor': {'links': links, 'map_version': thisMap['version']},
+                'corridor': {
+                    'links': links, 
+                    'map_versions': [hm['version'] for hm in hereMaps]
+                },
                 'query_params': query_params
             }
         }, cacheURI)
@@ -236,7 +239,10 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             'observations': [timeFormats(tt,1) for (dt,tt) in sample]
         },
         'query': {
-            'corridor': {'links': links, 'map_version': thisMap['version']},
+            'corridor': {
+                'links': links,
+                'map_versions': [hm['version'] for hm in hereMaps]
+            },
             'query_params': query_params
         }
     },cacheURI)

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -2,7 +2,7 @@
 
 from app.db import pool
 from app.links.here import get_here_links
-from app.hereMapVersions import bestMapVersion
+from app.hereMapVersions import selectMapVersions
 from traveltimetools.utils import timeFormats
 import numpy
 import math
@@ -86,12 +86,13 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             {holiday_clause}
     '''
 
-    map_version = bestMapVersion(start_date, end_date)
+    map_versions = selectMapVersions(start_date, end_date)
+    bestMapVersion = map_versions[0]
 
     links = get_here_links(
         start_node,
         end_node,
-        map_version
+        bestMapVersion
     )
 
     links_df = pandas.DataFrame({
@@ -154,7 +155,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 },
             },
             'query': {
-                'corridor': {'links': links, 'map_version': map_version},
+                'corridor': {'links': links, 'map_version': bestMapVersion},
                 'query_params': query_params
             }
         }, cacheURI)
@@ -186,7 +187,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             'observations': [timeFormats(tt,1) for (dt,tt) in sample]
         },
         'query': {
-            'corridor': {'links': links, 'map_version': map_version},
+            'corridor': {'links': links, 'map_version': bestMapVersion},
             'query_params': query_params
         }
     },cacheURI)

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -110,16 +110,17 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                     tuple(nodeA['geometry']['coordinates'][::-1]),
                     tuple(nodeB['geometry']['coordinates'][::-1]),
                     Unit.METERS
-                )
+                ), 'A node has moved by >= 10m between map versions'
             altLinks = get_here_links(start_node,end_node,altMap['version'])
             altLength = reduce(lambda a,b:a+b,[l['length_m'] for l in altLinks])
             # length must be < +/- 2% between map versions
             lengthRatio = linksLength/altLength
-            assert lengthRatio > 0.98 and lengthRatio < 1.02
+            if not (lengthRatio > 0.98 and lengthRatio < 1.02):
+                return {'error': 'length of corridors differs between map versions ' + thisMap['version'] + ' & ' + altMap['version']}
             # check street names for equality; assures no rerouting
             namesA = set([link['name'] for link in links])
             namesB = set([link['name'] for link in altLinks])
-            assert namesA == namesB
+            assert namesA == namesB, 'names of streets along corridor differ between map versions'
             # if all these assertions have passed, we're doing good!
             # proceed with the request, but break it up into chunks per map version
             newUpperDateLimit = min(

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -97,6 +97,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
 
     links = get_here_links(start_node,end_node,bestMap['version'])
     linksLength = reduce(lambda a,b:a+b,[l['length_m'] for l in links])
+
     # if this request spans multiple map versions...
     if len(hereMaps) > 1:
         for altMap in hereMaps[1:]:
@@ -119,7 +120,9 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             namesA = set([link['name'] for link in links])
             namesB = set([link['name'] for link in altLinks])
             assert namesA == namesB
-
+        # if all these assertions have passed, we're doing good!
+        # proceed with the request, but break it up into chunks per map version 
+        
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -12,6 +12,7 @@ import pandas
 import random
 import json
 from app.getGitHash import getGitHash
+from functools import reduce
 
 # the way we currently do it
 def mean_daily_mean(obs):
@@ -50,6 +51,9 @@ def cacheAndReturn(obj,uri):
                 cursor.execute(query, {'uri': uri, 'hash': getGitHash(), 'results': json.dumps(obj)})
             finally:
                 return obj
+
+def addLinkLengths(a,b):
+    return a['length_m'] + b['length_m']
 
 def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
@@ -92,6 +96,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     bestMap = hereMaps[0]
 
     links = get_here_links(start_node,end_node,bestMap['version'])
+    linksLength = reduce(lambda a,b:a+b,[l['length_m'] for l in links])
     # if this request spans multiple map versions...
     if len(hereMaps) > 1:
         for altMap in hereMaps[1:]:
@@ -106,8 +111,10 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                     Unit.METERS
                 )
             altLinks = get_here_links(start_node,end_node,altMap['version'])
-
-            print(altMap)
+            altLength = reduce(lambda a,b:a+b,[l['length_m'] for l in altLinks])
+            # length must be < +/- 2% between map versions
+            lengthRatio = linksLength/altLength
+            assert lengthRatio > 0.98 and lengthRatio < 1.02 
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -102,7 +102,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 nodeB = get_here_node(nodeId,hereMapVersion=altMap['version'])
                 assert 10 >= haversine(
                     tuple(nodeA['geometry']['coordinates'][::-1]),
-                    tuple(nodeA['geometry']['coordinates'][::-1]),
+                    tuple(nodeB['geometry']['coordinates'][::-1]),
                     Unit.METERS
                 )
             altLinks = get_here_links(start_node,end_node,altMap['version'])

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -57,7 +57,6 @@ def addLinkLengths(a,b):
 
 def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, subquery=False):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
-    print('func called with dates',start_date,end_date,subquery)
     # first check the cache
     cacheURI = f'/{start_node}/{end_node}/{start_time}/{end_time}/{start_date}/{end_date}/{str(include_holidays).lower()}/{"".join(map(str,dow_list))}'
     cachedValue = checkCache(cacheURI)
@@ -127,7 +126,6 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 end_date,
                 altMap['upperDateExclusive'] if altMap['upperDateExclusive'] else '9999-01-01' # TODO: Y10K problem
             )
-            print('proceeding to subquery for',altMap)
             subqueryObservations.append(get_travel_time(
                 start_node, end_node, start_time, end_time,
                 altMap['lowerDateInclusive'], # truncate date range to map version

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -87,13 +87,13 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     '''
 
     map_versions = selectMapVersions(start_date, end_date)
-    bestMapVersion = map_versions[0]
+    bestMapVersion = map_versions[0]['mapVersion']
 
-    links = get_here_links(
-        start_node,
-        end_node,
-        bestMapVersion
-    )
+    links = get_here_links(start_node,end_node,bestMapVersion)
+    # if this request spans multiple map versions...
+    if len(map_versions) > 1:
+        for map_version in map_versions[1:]:
+            print(map_version)
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -55,7 +55,7 @@ def cacheAndReturn(obj,uri):
 def addLinkLengths(a,b):
     return a['length_m'] + b['length_m']
 
-def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list):
+def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, subquery=False):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
 
     # first check the cache
@@ -93,18 +93,20 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     '''
 
     hereMaps = selectMapVersions(start_date, end_date)
-    bestMap = hereMaps[0]
+    thisMap = hereMaps[0] # chronologically the first map version
 
-    links = get_here_links(start_node,end_node,bestMap['version'])
-    linksLength = reduce(lambda a,b:a+b,[l['length_m'] for l in links])
+    links = get_here_links(start_node,end_node,thisMap['version'])
 
     # if this request spans multiple map versions...
     if len(hereMaps) > 1:
+        linksLength = reduce(lambda a,b:a+b,[l['length_m'] for l in links])
+        subqueryObservations = [] # store for observations from other map versions
+
         for altMap in hereMaps[1:]:
             # check that routing is basically the same on the other maps
             # first, check that start, end nodes exist and are in the same spot
             for nodeId in [start_node, end_node]:
-                nodeA = get_here_node(nodeId,hereMapVersion=bestMap['version'])
+                nodeA = get_here_node(nodeId,hereMapVersion=thisMap['version'])
                 nodeB = get_here_node(nodeId,hereMapVersion=altMap['version'])
                 assert 10 >= haversine(
                     tuple(nodeA['geometry']['coordinates'][::-1]),
@@ -120,9 +122,19 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             namesA = set([link['name'] for link in links])
             namesB = set([link['name'] for link in altLinks])
             assert namesA == namesB
-        # if all these assertions have passed, we're doing good!
-        # proceed with the request, but break it up into chunks per map version 
-        
+            # if all these assertions have passed, we're doing good!
+            # proceed with the request, but break it up into chunks per map version
+            print('proceeding to subquery for',altMap)
+            subqueryObservations += get_travel_time(
+                start_node, end_node, start_time, end_time,
+                altMap['lowerDateInclusive'], # truncate date range to map version
+                end_date, # unchanged because map versions chronological
+                include_holidays, dow_list,
+                subquery=True
+            )
+            print(subqueryObservations)
+        # limit the date range of this query to the current map version only
+        end_date = thisMap['upperDateExclusive']
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],
@@ -167,6 +179,10 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     observations = observations.assign(
         tt_extrapolated = lambda r: r.tt * total_corridor_length / r.length
     )
+    if subquery == True:
+        print(observations)
+        raise SystemExit
+        return observations
     # convert to format that can be used by the same summary function
     sample = []
     for tup in observations.itertuples():
@@ -184,7 +200,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 },
             },
             'query': {
-                'corridor': {'links': links, 'map_version': bestMap['version']},
+                'corridor': {'links': links, 'map_version': thisMap['version']},
                 'query_params': query_params
             }
         }, cacheURI)
@@ -216,7 +232,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             'observations': [timeFormats(tt,1) for (dt,tt) in sample]
         },
         'query': {
-            'corridor': {'links': links, 'map_version': bestMap['version']},
+            'corridor': {'links': links, 'map_version': thisMap['version']},
             'query_params': query_params
         }
     },cacheURI)

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -106,11 +106,13 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             for nodeId in [start_node, end_node]:
                 nodeA = get_here_node(nodeId,hereMapVersion=thisMap['version'])
                 nodeB = get_here_node(nodeId,hereMapVersion=altMap['version'])
-                assert 10 >= haversine(
+                nodeDrift = haversine(
                     tuple(nodeA['geometry']['coordinates'][::-1]),
                     tuple(nodeB['geometry']['coordinates'][::-1]),
                     Unit.METERS
-                ), 'A node has moved by >= 10m between map versions'
+                )
+                if nodeDrift >= 10:
+                    return {'error': f'Node {nodeId} moved by ({nodeDrift}m) between map versions '+ thisMap['version'] + ' & ' + altMap['version']}
             altLinks = get_here_links(start_node,end_node,altMap['version'])
             altLength = reduce(lambda a,b:a+b,[l['length_m'] for l in altLinks])
             # length must be < +/- 2% between map versions
@@ -120,8 +122,9 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             # check street names for equality; assures no rerouting
             namesA = set([link['name'] for link in links])
             namesB = set([link['name'] for link in altLinks])
-            assert namesA == namesB, 'names of streets along corridor differ between map versions'
-            # if all these assertions have passed, we're doing good!
+            if namesA != namesB:
+                return {'error': 'names of streets along corridor differ between map versions ' + thisMap['version'] + ' & ' + altMap['version']}
+            # if all these checks have passed, we're doing good!
             # proceed with the request, but break it up into chunks per map version
             newUpperDateLimit = min(
                 end_date,

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -4,15 +4,15 @@ from app.db import pool
 from app.links.here import get_here_links
 from app.nodes.byID.here import get_here_node
 from app.hereMapVersions import selectMapVersions
+from app.getGitHash import getGitHash
 from traveltimetools.utils import timeFormats
 from haversine import haversine, Unit
+from functools import reduce
 import numpy
 import math
 import pandas
 import random
 import json
-from app.getGitHash import getGitHash
-from functools import reduce
 
 # the way we currently do it
 def mean_daily_mean(obs):
@@ -57,7 +57,7 @@ def addLinkLengths(a,b):
 
 def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, subquery=False):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
-
+    print('func called with dates',start_date,end_date,subquery)
     # first check the cache
     cacheURI = f'/{start_node}/{end_node}/{start_time}/{end_time}/{start_date}/{end_date}/{str(include_holidays).lower()}/{"".join(map(str,dow_list))}'
     cachedValue = checkCache(cacheURI)
@@ -96,12 +96,11 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     thisMap = hereMaps[0] # chronologically the first map version
 
     links = get_here_links(start_node,end_node,thisMap['version'])
+    subqueryObservations = [] # store for observations from other map versions, if any
 
     # if this request spans multiple map versions...
     if len(hereMaps) > 1:
         linksLength = reduce(lambda a,b:a+b,[l['length_m'] for l in links])
-        subqueryObservations = [] # store for observations from other map versions
-
         for altMap in hereMaps[1:]:
             # check that routing is basically the same on the other maps
             # first, check that start, end nodes exist and are in the same spot
@@ -124,15 +123,19 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             assert namesA == namesB
             # if all these assertions have passed, we're doing good!
             # proceed with the request, but break it up into chunks per map version
+            newUpperDateLimit = min(
+                end_date,
+                altMap['upperDateExclusive'] if altMap['upperDateExclusive'] else '9999-01-01' # TODO: Y10K problem
+            )
             print('proceeding to subquery for',altMap)
-            subqueryObservations += get_travel_time(
+            subqueryObservations.append(get_travel_time(
                 start_node, end_node, start_time, end_time,
                 altMap['lowerDateInclusive'], # truncate date range to map version
-                end_date, # unchanged because map versions chronological
+                newUpperDateLimit,
                 include_holidays, dow_list,
                 subquery=True
-            )
-            print(subqueryObservations)
+            ))
+        #pandas.concat(subqueryObservations)
         # limit the date range of this query to the current map version only
         end_date = thisMap['upperDateExclusive']
 
@@ -180,9 +183,12 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         tt_extrapolated = lambda r: r.tt * total_corridor_length / r.length
     )
     if subquery == True:
-        print(observations)
-        raise SystemExit
+        # these will be incorporated directly into the main/first query
         return observations
+    elif len(subqueryObservations) > 0:
+        # merge observations from this and any subqueries
+        observations = pandas.concat([observations] + subqueryObservations)
+
     # convert to format that can be used by the same summary function
     sample = []
     for tup in observations.itertuples():

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -114,7 +114,12 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             altLength = reduce(lambda a,b:a+b,[l['length_m'] for l in altLinks])
             # length must be < +/- 2% between map versions
             lengthRatio = linksLength/altLength
-            assert lengthRatio > 0.98 and lengthRatio < 1.02 
+            assert lengthRatio > 0.98 and lengthRatio < 1.02
+            # check street names for equality; assures no rerouting
+            namesA = set([link['name'] for link in links])
+            namesB = set([link['name'] for link in altLinks])
+            assert namesA == namesB
+
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -2,8 +2,10 @@
 
 from app.db import pool
 from app.links.here import get_here_links
+from app.nodes.byID.here import get_here_node
 from app.hereMapVersions import selectMapVersions
 from traveltimetools.utils import timeFormats
+from haversine import haversine, Unit
 import numpy
 import math
 import pandas
@@ -86,14 +88,26 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             {holiday_clause}
     '''
 
-    map_versions = selectMapVersions(start_date, end_date)
-    bestMapVersion = map_versions[0]['mapVersion']
+    hereMaps = selectMapVersions(start_date, end_date)
+    bestMap = hereMaps[0]
 
-    links = get_here_links(start_node,end_node,bestMapVersion)
+    links = get_here_links(start_node,end_node,bestMap['version'])
     # if this request spans multiple map versions...
-    if len(map_versions) > 1:
-        for map_version in map_versions[1:]:
-            print(map_version)
+    if len(hereMaps) > 1:
+        for altMap in hereMaps[1:]:
+            # check that routing is basically the same on the other maps
+            # first, check that start, end nodes exist and are in the same spot
+            for nodeId in [start_node, end_node]:
+                nodeA = get_here_node(nodeId,hereMapVersion=bestMap['version'])
+                nodeB = get_here_node(nodeId,hereMapVersion=altMap['version'])
+                assert 10 >= haversine(
+                    tuple(nodeA['geometry']['coordinates'][::-1]),
+                    tuple(nodeA['geometry']['coordinates'][::-1]),
+                    Unit.METERS
+                )
+            altLinks = get_here_links(start_node,end_node,altMap['version'])
+
+            print(altMap)
 
     links_df = pandas.DataFrame({
         'link_dir': [l['link_dir'] for l in links],
@@ -155,7 +169,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 },
             },
             'query': {
-                'corridor': {'links': links, 'map_version': bestMapVersion},
+                'corridor': {'links': links, 'map_version': bestMap['version']},
                 'query_params': query_params
             }
         }, cacheURI)
@@ -187,7 +201,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             'observations': [timeFormats(tt,1) for (dt,tt) in sample]
         },
         'query': {
-            'corridor': {'links': links, 'map_version': bestMapVersion},
+            'corridor': {'links': links, 'map_version': bestMap['version']},
             'query_params': query_params
         }
     },cacheURI)

--- a/backend/app/hereMapVersions.py
+++ b/backend/app/hereMapVersions.py
@@ -8,11 +8,16 @@ query_if_dates_provided = """
 WITH coverage AS (
     SELECT
         street_version,
+        lower(valid_range) AS lower,
+        upper(valid_range) AS upper,
         valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
     FROM here.street_valid_range
 )
 
-SELECT street_version
+SELECT
+    street_version,
+    lower,
+    upper
 FROM coverage
 WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
 ORDER BY UPPER(overlap) - LOWER(overlap) DESC;
@@ -25,11 +30,12 @@ def selectMapVersions(start_date, end_date):
                 query_if_dates_provided,
                 {'start_date':start_date,'end_date':end_date}
             )
-            map_versions = [mv for (mv,) in cursor.fetchall()]
+            map_versions = [{
+                'mapVersion': mv,
+                'lowerDateInclusive': lower,
+                'upperDateExclusive': upper
+            } for (mv,lower,upper) in cursor.fetchall()]
     return map_versions
-
-def bestMapVersion(start_date,end_date):
-    return selectMapVersions(start_date,end_date)[0]
 
 query_for_latest_date = """
 SELECT street_version

--- a/backend/app/hereMapVersions.py
+++ b/backend/app/hereMapVersions.py
@@ -8,8 +8,8 @@ query_if_dates_provided = """
 WITH coverage AS (
     SELECT
         street_version,
-        lower(valid_range) AS lower,
-        upper(valid_range) AS upper,
+        lower(valid_range)::text AS lower,
+        upper(valid_range)::text AS upper,
         valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
     FROM here.street_valid_range
 )

--- a/backend/app/hereMapVersions.py
+++ b/backend/app/hereMapVersions.py
@@ -5,22 +5,13 @@ from app.dates import maxDate
 # query, or latest available date if those are not provided
 
 query_if_dates_provided = """
-WITH coverage AS (
-    SELECT
-        street_version,
-        lower(valid_range)::text AS lower,
-        upper(valid_range)::text AS upper,
-        valid_range * daterange(%(start_date)s, %(end_date)s,'[)') AS overlap
-    FROM here.street_valid_range
-)
-
 SELECT
     street_version,
-    lower,
-    upper
-FROM coverage
-WHERE UPPER(overlap) - LOWER(overlap) IS NOT NULL
-ORDER BY UPPER(overlap) - LOWER(overlap) DESC;
+    lower(valid_range)::text AS lower,
+    upper(valid_range)::text AS upper
+FROM here.street_valid_range
+WHERE valid_range && daterange(%(start_date)s, %(end_date)s,'[)')
+ORDER BY lower
 """
 
 def selectMapVersions(start_date, end_date):

--- a/backend/app/hereMapVersions.py
+++ b/backend/app/hereMapVersions.py
@@ -31,7 +31,7 @@ def selectMapVersions(start_date, end_date):
                 {'start_date':start_date,'end_date':end_date}
             )
             map_versions = [{
-                'mapVersion': mv,
+                'version': mv,
                 'lowerDateInclusive': lower,
                 'upperDateExclusive': upper
             } for (mv,lower,upper) in cursor.fetchall()]

--- a/backend/app/hereMapVersions.py
+++ b/backend/app/hereMapVersions.py
@@ -25,7 +25,7 @@ def selectMapVersions(start_date, end_date):
                 query_if_dates_provided,
                 {'start_date':start_date,'end_date':end_date}
             )
-        map_versions = [mv for (mv,) in cursor.fetchall()]
+            map_versions = [mv for (mv,) in cursor.fetchall()]
     return map_versions
 
 def bestMapVersion(start_date,end_date):

--- a/backend/app/nodes/byID/here.py
+++ b/backend/app/nodes/byID/here.py
@@ -22,9 +22,8 @@ GROUP BY
     here_nodes.geom;
 '''
 
-def get_here_node(node_id, conflate_with_centreline=False):
-    map_version = latestMapVersion() # current/latest map version
-    map_version = '23_4'
+def get_here_node(node_id, conflate_with_centreline=False,hereMapVersion=None):
+    map_version = hereMapVersion if hereMapVersion else latestMapVersion()
     versioned_node_query = sql.SQL(node_query).format(
         routing_nodes = sql.Identifier(f'routing_nodes_{map_version}'),
         street_attributes_table = sql.Identifier(f'streets_att_{map_version}')

--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -164,6 +164,6 @@ export class SpatialData {
     }
     get queryCount(){ return this.#queries.size }
     get queryCountFinished(){
-        return [...this.#queries.values()].filter(q=>q.hasData).length
+        return [...this.#queries.values()].filter(q=>q.isFinished).length
     }
 }

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -7,6 +7,7 @@ export class TravelTimeQuery {
     #days
     #holidayOption
     #results
+    #errorMessage
     constructor({corridor,timeRange,dateRange,days,holidayOption}){
         this.#corridor = corridor
         this.#timeRange = timeRange
@@ -39,10 +40,17 @@ export class TravelTimeQuery {
         }
         return fetch(this.URI)
             .then( response => response.json() )
-            .then( data => this.#results = data.results )
+            .then( data => {
+                this.#results = data?.results
+                this.#errorMessage = data?.error
+            } )
+            .catch( this.#errorMessage = 'unhandled server error' )
     }
     get hasData(){
         return Boolean(this.#results)
+    }
+    get isFinished(){
+        return this.hasData || Boolean(this.#errorMessage)
     }
     get hoursInRange(){ // number of hours covered by query options
         let hoursPerDay = this.timeRange.hoursInRange
@@ -80,6 +88,7 @@ export class TravelTimeQuery {
         record.set('hoursInRange', this.hoursInRange)
         record.set('mean_travel_time_minutes', this.#results?.travel_time?.minutes)
         record.set('mean_travel_time_seconds', this.#results?.travel_time?.seconds)
+        record.set('notes',this.#errorMessage)
         // turning these off in the frontend until they're ready for production
         //record.set('moe_lower_p95', this.#results?.confidence?.intervals?.['p=0.95']?.lower?.seconds)
         //record.set('moe_upper_p95', this.#results?.confidence?.intervals?.['p=0.95']?.upper?.seconds)


### PR DESCRIPTION
Closes #196

How this works:
* The map versions lookup function now returns a chronological list of all relevant map versions, rather than the single best match.
* The initial call to `get_travel_time` proceeds only with the first map version, constraining its date range to the relevant period
* For the other map versions it fires off recursive subqueries (to the same function, but with the `subquery` flag marked as `True`), again with constrained dates. These return early with the pandas dataframe of the travel time observations for their period. 
* The initial query, once it gathers the results of the subqueries combines them with its own observations (`pandas.concat`) and proceeds to with the rest of its work: estimate confidence from all the observations and format results. 

If any of the map versions do not very closely align to the routed geometry of the first relevant map version, error messages will be returned. Given that this change will then make error messages more common, I've started to handle these by reporting error messages in a new field in the output: 'notes'. I may extend that field later.

This function is now something of a mess and needs refactoring.