### PR TITLE
Promote corridor geojson download

### DIFF
--- a/frontend/src/Sidebar/ResultsContainer.jsx
+++ b/frontend/src/Sidebar/ResultsContainer.jsx
@@ -39,11 +39,6 @@ export default function ResultsContainer(){
                     >
                         <BigButton>Download results as CSV </BigButton>
                     </a>
-                    <a download='corridors.geojson'
-                        href={`data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(corridorsGeoJSON(data.corridors)))}`}
-                    >
-                        <BigButton>Download corridors as GeoJSON</BigButton>
-                    </a>
                 </>
             }
         </div>
@@ -57,12 +52,4 @@ function ProgressBar({percentDone}){
             <rect height='100%' width={percentDone} fill='darkgreen' strokeWidth='1'/>
         </svg>
     )
-}
-
-function corridorsGeoJSON(corridors){
-    let geojson = {
-        type: 'FeatureCollection',
-        features: corridors.map( c => c.geojsonFeaturesLinear )
-    }
-    return geojson
 }

--- a/frontend/src/Sidebar/index.jsx
+++ b/frontend/src/Sidebar/index.jsx
@@ -74,12 +74,23 @@ export function CorridorsContainer(){
                 Create a new corridor
             </BigButton>
             {data.corridors.some(c => c.isComplete) &&
-                <BigButton>Download mapped corridors</BigButton>
+                <a download='corridors.geojson'
+                        href={`data:text/plain;charset=utf-8,${encodeURIComponent(JSON.stringify(corridorsGeoJSON(data.corridors)))}`}
+                    >
+                    <BigButton>Download mapped corridors</BigButton>
+                </a>
             }
             <FactorList factors={data.corridors}/>
-            
         </FactorContainer>
     )
+}
+
+function corridorsGeoJSON(corridors){
+    let geojson = {
+        type: 'FeatureCollection',
+        features: corridors.map( c => c.geojsonFeaturesLinear )
+    }
+    return geojson
 }
 
 function DaysContainer(){

--- a/frontend/src/Sidebar/index.jsx
+++ b/frontend/src/Sidebar/index.jsx
@@ -73,7 +73,11 @@ export function CorridorsContainer(){
             <BigButton onClick={addACorridor}>
                 Create a new corridor
             </BigButton>
+            {data.corridors.some(c => c.isComplete) &&
+                <BigButton>Download mapped corridors</BigButton>
+            }
             <FactorList factors={data.corridors}/>
+            
         </FactorContainer>
     )
 }


### PR DESCRIPTION
Move the corridor geojson download to a more prominent place in the UI. No more need to finish querying travel times to get the download button - all that's needed is a complete corridor on the map.

This, in combination with #212 should make it easier to save and restore app state for large data requests