### PR TITLE
Return URI instead of corridor geometries with travel times

### DIFF
--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -113,7 +113,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 )
                 if nodeDrift >= 10:
                     return {'error': f'Node {nodeId} moved by ({nodeDrift}m) between map versions '+ thisMap['version'] + ' & ' + altMap['version']}
-            altLinks = get_here_links(start_node,end_node,altMap['version'])
+            altLinks, altURI = get_here_links(start_node,end_node,altMap['version'])
             altLength = reduce(lambda a,b:a+b,[l['length_m'] for l in altLinks])
             # length must be < +/- 2% between map versions
             lengthRatio = linksLength/altLength

--- a/backend/app/get_travel_time.py
+++ b/backend/app/get_travel_time.py
@@ -94,7 +94,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     hereMaps = selectMapVersions(start_date, end_date)
     thisMap = hereMaps[0] # chronologically the first map version
 
-    links = get_here_links(start_node,end_node,thisMap['version'])
+    links, corridorURI = get_here_links(start_node,end_node,thisMap['version'])
     subqueryObservations = [] # store for observations from other map versions, if any
 
     # if this request spans multiple map versions...
@@ -209,7 +209,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             },
             'query': {
                 'corridor': {
-                    'links': links, 
+                    'links': corridorURI, 
                     'map_versions': [hm['version'] for hm in hereMaps]
                 },
                 'query_params': query_params
@@ -244,7 +244,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         },
         'query': {
             'corridor': {
-                'links': links,
+                'links': corridorURI,
                 'map_versions': [hm['version'] for hm in hereMaps]
             },
             'query_params': query_params

--- a/backend/app/links/here.py
+++ b/backend/app/links/here.py
@@ -24,7 +24,7 @@ def cacheAndReturn(obj,uri):
                     {'uri': uri,'hash':getGitHash(),'results':json.dumps(obj)}
                 )
             finally:
-                return obj
+                return obj, uri
 
 def checkCache(uri):
     with pool.connection() as connection:
@@ -35,7 +35,7 @@ def checkCache(uri):
                     {'uri':uri,'hash':getGitHash()}
                 )
                 for (record,) in cursor: # will skip if no records
-                    return record # there could only be one because of constraint
+                    return record, uri # there could only be one because of constraint
             except:
                 pass
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -121,7 +121,7 @@ def get_here_links_between_two_nodes(from_node_id, to_node_id):
             # which will expose database errors
             links, URI = get_here_links(from_node_id,to_node_id,map_version)
         else:
-            links = get_here_links(from_node_id,to_node_id)
+            links, URI = get_here_links(from_node_id,to_node_id)
     elif request.endpoint == 'centreline-links':
         links = get_centreline_links(from_node_id, to_node_id)
 

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -119,7 +119,7 @@ def get_here_links_between_two_nodes(from_node_id, to_node_id):
         if map_version and re.fullmatch(r'^\d{2}_\d$', map_version):
             # TODO: can pass map versions that match the pattern but don't exist
             # which will expose database errors
-            links = get_here_links(from_node_id,to_node_id,map_version)
+            links, URI = get_here_links(from_node_id,to_node_id,map_version)
         else:
             links = get_here_links(from_node_id,to_node_id)
     elif request.endpoint == 'centreline-links':


### PR DESCRIPTION
I don't think there are any actual cases where corridor geometries are used in this context. Instead of returning those, I'm now returning a URI for that data which means it's still accessible if needed - just with one extra request. 

This reduces bandwidth and other costs of storing and managing many travel time requests. Importantly, it still lets us check and version the corridors used just as well - in fact, somewhat more easily since the whole thing is now represented as a simple, distinct string. 