### PR TITLE
Order routed centreline edges

### DIFF
--- a/backend/app/links/centreline.py
+++ b/backend/app/links/centreline.py
@@ -49,14 +49,16 @@ def get_centreline_links(from_node_id, to_node_id):
                     'nodes': [source, target]
                 } for centreline_id, st_name, geojson, length_m, source, target in cursor.fetchall()
             ]
-    # sort by hopping from node to node
+    # sort by hopping down the route from node to node
     sorted_links = []
-    start_node = from_node_id
+    activeNode = from_node_id
     while len(links) > 0:
-        next_link = findPop(links, lambda link: start_node in link['nodes'] )
-        next_link['source'] = start_node
-        next_link['target'] = next(n for n in next_link['nodes'] if n != start_node)
-        start_node = next_link['target']
-        del next_link['nodes']
-        sorted_links.append(next_link)
+        link = findPop(links, lambda link: activeNode in link['nodes'] )
+        if link['nodes'][0] != activeNode:
+            link['nodes'].reverse()
+            link['geometry']['coordinates'].reverse()
+        link['source'] = link['nodes'][0]
+        activeNode = link['target'] = link['nodes'][1]
+        del link['nodes']
+        sorted_links.append(link)
     return sorted_links

--- a/backend/app/links/centreline.py
+++ b/backend/app/links/centreline.py
@@ -22,13 +22,13 @@ FROM centreline_path
 JOIN gis_core.centreline_latest USING (centreline_id)
 '''
 
-# pop from a list my a match function
+# pop from a list by a match function
 def findPop(aList, matchFunc):
     item = next(filter(matchFunc, aList))
     index = aList.index(item)
     return aList.pop(index)
 
-# returns a json with ordered, directed geometries of links between two nodes
+# returns a list with ordered, directed geometries of links between two nodes
 def get_centreline_links(from_node_id, to_node_id):
     with pool.connection() as connection:
         with connection.cursor() as cursor:
@@ -49,7 +49,7 @@ def get_centreline_links(from_node_id, to_node_id):
                     'nodes': [source, target]
                 } for centreline_id, st_name, geojson, length_m, source, target in cursor.fetchall()
             ]
-    # sort by hopping down the route from node to node
+    # sort by hopping down the route sequentially from node to node
     sorted_links = []
     activeNode = from_node_id
     while len(links) > 0:

--- a/backend/app/links/centreline.py
+++ b/backend/app/links/centreline.py
@@ -1,6 +1,7 @@
 import json
 from app.db import pool
 
+# returns a set of not-necessarily-ordered undirected links
 links_query = '''
 WITH centreline_path AS (
     SELECT unnest(links)::int AS centreline_id
@@ -14,14 +15,20 @@ SELECT
     centreline_id,
     linear_name_full_legal AS st_name,
     ST_AsGeoJSON(geom) AS geojson,
-    ST_length(ST_Transform(geom, 2952)) AS length_m,
+    ST_length(ST_Transform(geom, 2952))::real AS length_m,
     from_intersection_id,
     to_intersection_id
 FROM centreline_path
 JOIN gis_core.centreline_latest USING (centreline_id)
 '''
 
-# returns a json with geometries of links between two nodes
+# pop from a list my a match function
+def findPop(aList, matchFunc):
+    item = next(filter(matchFunc, aList))
+    index = aList.index(item)
+    return aList.pop(index)
+
+# returns a json with ordered, directed geometries of links between two nodes
 def get_centreline_links(from_node_id, to_node_id):
     with pool.connection() as connection:
         with connection.cursor() as cursor:
@@ -32,16 +39,24 @@ def get_centreline_links(from_node_id, to_node_id):
                     "to_node_id": to_node_id
                 }
             )
-
+            # get the unordered data in memory
             links = [
                 {
                     'centreline_id': centreline_id,
                     'name': st_name,
-                    #'sequence': seq,
                     'geometry': json.loads(geojson),
                     'length_m': length_m,
-                    'source': source,
-                    'target': target
+                    'nodes': [source, target]
                 } for centreline_id, st_name, geojson, length_m, source, target in cursor.fetchall()
             ]
-    return links
+    # sort by hopping from node to node
+    sorted_links = []
+    start_node = from_node_id
+    while len(links) > 0:
+        next_link = findPop(links, lambda link: start_node in link['nodes'] )
+        next_link['source'] = start_node
+        next_link['target'] = next(n for n in next_link['nodes'] if n != start_node)
+        start_node = next_link['target']
+        del next_link['nodes']
+        sorted_links.append(next_link)
+    return sorted_links


### PR DESCRIPTION
Routed centrelines have been returned in no particular order, with no particular direction. This
* sorts the list sequentially from start to end nodes
* correctly identifies the source (start) and target (end) node Ids
    * which may now _not_ match what's in `centreline_latest`
* reverses geometries where necessary to ensure the route is actually drawn in the correct direction

The reason for these changes is that it sets me up for looking at _directed_ centreline-based AADTs in the corridor explorer which uses this API. This change will not effect anything related to travel times.