### PR TITLE
Dynamic binning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When you [visit the app](https://trans-bdit.intra.prod-toronto.ca/traveltime-req
 
 | Factor | Description |
 | ----- | ----------- |
-| Corridor | Drawn on the map, it is a shortest path between two intersections of your choice. Draw it in both directions if you need both directions of travel. |
+| Corridor | Drawn on the map, it is a shortest path between two intersections of your choice. Draw it in both directions if you need both directions of travel. Be cautious about drawing corridors longer than a couple of kilometers, as the aggregation methods are not well tested for very long corridors. |
 | Time Range | Times must start and end on the hour and the app accepts integer values between 0 and 24. The final hour is _exclusive_, meaning that a range of 7am to 9am covers two hours, not three. Values of 0 and 24 both interchangeably represent midnight; a time range of 0 - 24 will return all hours of the day. A time range starting after it ends (e.g. 10pm to 4am) will wrap around midnight[^1]. |
 | Date Range | Use the calendar widget to select a date range. Note that selected ranges are displayed with an exclusive end date. |
 | Day of Week | Identify the days of week to include in the aggregation. |

--- a/README.md
+++ b/README.md
@@ -59,15 +59,13 @@ Data for travel time estimation through the app are sourced from [HERE](https://
 
 The number of vehicles within the City of Toronto reporting their position to HERE in this way has been [estimated](./analysis/total-fleet-size.r) to be around 2,000 to 3,000 vehicles during the AM and PM peak periods, with lower numbers in the off hours. While this may seem like a lot, in practice many of these vehicles are on the highways and the coverage of any particular city street within a several hour time window can be very minimal if not nil. For this reason, we are currently restricting travel time estimates to "arterial" streets and highways.
 
-Travel times are provided to us in the form of _average speeds_ along links of the street network in 5-minute time bins. Given the sparseness of the vehicle probe data, most links, in most time bins are empty. The scond most common sample size is a single vehicle observation.
+Travel times are provided to us in the form of _average speeds_ along links of the street network in 5-minute time bins. Given the sparseness of the vehicle probe data, most links, in most time bins are empty. The scond most common sample size is a single vehicle observation. This means the "average speed" we get it typically just the actual speed of a single vehicle.
 
-Before generating an averaged travel time, we do several steps to aggregate and average this sparse data into larger units. 
+Before generating an averaged travel time, we do several steps to aggregate and average this sparse data into larger units.
 * We aggregate _links_ spatially into longer _corridors_ between major intersections
-* We aggregate _corridors_ temporally into one-hour bins
+* We aggregate _corridors_ temporally into bins having data coverage over 80% or more of the corridor by length. These bins can't be longer than 30 minutes (6 consecutive 5-minute bins)
 
-We generate averaged travel times from these one-hour-corridor bin units where one or more vehicles has travelled 80% or more of the length of the corridor.
-
-We aggregate corridors together spatially as necessary into larger corridors where 80% or more of segments have met the criteria above. Where data is missing it is extrapolated at the average speed over the rest of the length.
+Where data is missing it is extrapolated at the average speed over the 80%+ of the length which did have data.
 
 ### Other means of estimating travel times
 

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -22,11 +22,6 @@ class DynamicBin:
 
     def extendTo(self, newBin):
         assert isinstance(newBin, FiveMinBin) 
-        # remove any prior bins from a different date
-        self.subBins = [
-            b for b in self.subBins
-            if b.date == newBin.date
-        ]
         # remove any prior bins from too long ago
         self.subBins = [ 
             b for b in self.subBins
@@ -73,10 +68,10 @@ class DynamicBin:
 
     @property
     def dates(self):
-        # intending this to wrap dates eventually, thus allowing mutliples 
-        return set( bin.date for bin in self.subBins)
-    
+        # dynamic bins may cross midnight
+        return set(bin.date for bin in self.subBins)
+
     @property
-    def date(self):
+    def singleDate(self):
         # simple implementation for now
         return self.subBins[0].date

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -25,7 +25,7 @@ class DynamicBin:
         # remove any prior bins from too long ago
         self.subBins = [ 
             b for b in self.subBins
-            if b.binNum >= newBin.binNum - maxBinsPerDynamicBin
+            if b.binNum > newBin.binNum - maxBinsPerDynamicBin
         ]
         # finally, add the new bin
         self.subBins.append(newBin)

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -21,7 +21,7 @@ class DynamicBin:
         return self.totalLength * minimumCoverageThreshold
 
     def extendTo(self, newBin):
-        assert isinstance(newBin, FiveMinBin) 
+        assert isinstance(newBin, FiveMinBin)
         # remove any prior bins from too long ago
         self.subBins = [ 
             b for b in self.subBins
@@ -29,6 +29,11 @@ class DynamicBin:
         ]
         # finally, add the new bin
         self.subBins.append(newBin)
+        # bust the cached value, if it exists
+        try:
+            del self.extrapolatedTravelTime
+        except:
+            pass
 
     @property
     def isComplete(self):
@@ -46,7 +51,13 @@ class DynamicBin:
 
     @property
     def travelTime(self):
-        extrapolatedTravelTime = polars.concat(
+        # this can be requested a lot for bootstrapping, etc, so cache in memory
+        try:
+            return self.extrapolatedTravelTime
+        except:
+            pass
+
+        self.extrapolatedTravelTime = polars.concat(
             [bin.linkTravelTimes for bin in self.subBins]
         ).join(
             self.corridorLinks,
@@ -64,7 +75,7 @@ class DynamicBin:
             ).alias('extrapolatedTravelTime')
         ).item()
 
-        return extrapolatedTravelTime
+        return self.extrapolatedTravelTime
 
     @property
     def dates(self):

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -1,0 +1,84 @@
+import polars
+
+# arbitrary number we've been using for at least a few years
+# specifies that at least 80% of corridor by length must have _some_ data
+minimumCoverageThreshold = 0.8
+
+# how long can a dynamic bin get?
+maximumBinLengthMinutes = 30
+nativeBinSizeMinutes = 5
+maxBinsPerDynamicBin = maximumBinLengthMinutes / nativeBinSizeMinutes
+
+class DynamicBin:
+    def __init__(self, links):
+        self.corridorLinks = links
+        self.subBins = list()
+        self.totalLength = links['length'].sum()
+
+    @property
+    def minLength(self):
+        return self.totalLength * minimumCoverageThreshold
+
+    def extendTo(self, newBin):
+        # remove any prior bins from a different date
+        self.subBins = [
+            b for b in self.subBins
+            if b.date == newBin.date
+        ]
+        # remove any prior bins from too long ago
+        self.subBins = [ 
+            b for b in self.subBins
+            if b.binNum >= newBin.binNum - maxBinsPerDynamicBin
+        ]
+        # finally, add the new bin
+        self.subBins.append(newBin)
+
+    @property
+    def isComplete(self):
+        # check length of the distinct links in sub-bins against threshold
+        uniqueLinkdirs = set(
+            linkdir
+            for bin in self.subBins
+            for linkdir in bin.linkdirs
+        )
+        links = self.corridorLinks.filter(
+            polars.col('link_dir').is_in(uniqueLinkdirs)
+        )
+        lengthSoFar = links['length'].sum()
+        return lengthSoFar >= self.minLength
+
+    @property
+    def travelTime(self):
+        extrapolatedTravelTime = polars.concat(
+            [bin.linkTravelTimes for bin in self.subBins]
+        ).join(
+            self.corridorLinks,
+            on='link_dir'
+        ).group_by(
+            ['link_dir','length']
+        ).agg(
+            polars.col('travelTime').mean().alias('link_avg_tt')
+        ).select(
+            polars.col('link_avg_tt').sum().alias('totalObservedTravelTime'),
+            polars.col('length').sum().alias('totalObservedLength')
+        ).select(
+            ( # extrapolate over missing data within each hour
+                polars.col('totalObservedTravelTime') * self.totalLength / polars.col('totalObservedLength')
+            ).alias('extrapolatedTravelTime')
+        ).item()
+
+        return extrapolatedTravelTime
+
+    @property
+    def dates(self):
+        # intending this to wrap dates eventually, thus allowing mutliples 
+        return set( bin.date for bin in self.subBins)
+    
+    @property
+    def date(self):
+        # simple implementation for now
+        return self.subBins[0].date
+
+    @property
+    def length(self):
+        return len(self.subBins)

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -80,7 +80,3 @@ class DynamicBin:
     def date(self):
         # simple implementation for now
         return self.subBins[0].date
-
-    @property
-    def length(self):
-        return len(self.subBins)

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -75,3 +75,11 @@ class DynamicBin:
     def singleDate(self):
         # simple implementation for now
         return self.subBins[0].date
+
+    @property
+    def startTime(self):
+        return self.subBins[0].startTime
+
+    @property
+    def endTime(self):
+        return self.subBins[-1].endTime

--- a/backend/app/travel_times/DynamicBin.py
+++ b/backend/app/travel_times/DynamicBin.py
@@ -1,7 +1,8 @@
 import polars
+from app.travel_times.FiveMinBin import FiveMinBin
 
 # arbitrary number we've been using for at least a few years
-# specifies that at least 80% of corridor by length must have _some_ data
+# specifies that at least 80% of corridor by length must have *some* data
 minimumCoverageThreshold = 0.8
 
 # how long can a dynamic bin get?
@@ -20,6 +21,7 @@ class DynamicBin:
         return self.totalLength * minimumCoverageThreshold
 
     def extendTo(self, newBin):
+        assert isinstance(newBin, FiveMinBin) 
         # remove any prior bins from a different date
         self.subBins = [
             b for b in self.subBins

--- a/backend/app/travel_times/FiveMinBin.py
+++ b/backend/app/travel_times/FiveMinBin.py
@@ -1,0 +1,15 @@
+class FiveMinBin:
+    def __init__(self, dt, binNum, times_df):
+        self.dt = dt
+        self.binNum = binNum
+        self.linkdirs = set(times_df['link_dir'])
+        self.times = times_df
+    @property
+    def date(self):
+        return self.dt
+    @property
+    def linksdirs(self):
+        return self.linkdirs
+    @property
+    def linkTravelTimes(self):
+        return self.times

--- a/backend/app/travel_times/FiveMinBin.py
+++ b/backend/app/travel_times/FiveMinBin.py
@@ -1,15 +1,23 @@
+from datetime import datetime
+
 class FiveMinBin:
-    def __init__(self, dt, binNum, times_df):
-        self.dt = dt
+    def __init__(self, binNum, times_df):
         self.binNum = binNum
         self.linkdirs = set(times_df['link_dir'])
         self.times = times_df
     @property
     def date(self):
-        return self.dt
+        return self.startTime.strftime('%Y-%m-%d')
     @property
     def linksdirs(self):
         return self.linkdirs
     @property
     def linkTravelTimes(self):
         return self.times
+    @property
+    def startTime(self):
+        return datetime.fromtimestamp(self.binNum * 300)
+    @property
+    def endTime(self):
+        """Exclusive end, so stop a millisecond shy of the actual time"""
+        return datetime.fromtimestamp(self.binNum * 300 + 299.999)

--- a/backend/app/travel_times/daily_aggregation.py
+++ b/backend/app/travel_times/daily_aggregation.py
@@ -1,18 +1,17 @@
 import numpy
+import polars
 
 # Q: Is this the ideal way to do this? 
 # A: It is the way we currently do it.
-def mean_daily_mean(obs):
-    """Takes a list of tuples like [(date, numeric),...] and returns
-    the average of the daily averages"""
+def mean_daily_mean(observations):
+    """Takes a list of DynamicBins and returns
+    the *average* of the *daily averages*"""
 
-    # group the observations by date
-    dates = {}
-    for (dt,tt) in obs:
-        dates[dt] = [tt] if not dt in dates else dates[dt] + [tt]
-
-    # take the daily averages
-    daily_means = [ numpy.mean(times) for times in dates.values() ]
-
-    # average the days together
-    return numpy.mean(daily_means)
+    return polars.DataFrame({
+        'date': [bin.singleDate for bin in observations],
+        'travelTime': [bin.travelTime for bin in observations]
+    }).group_by('date').agg(
+        polars.col('travelTime').mean().alias('travelTime')
+    ).select(
+        polars.col('travelTime').mean()
+    ).item()

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -1,3 +1,5 @@
+import polars
+
 # arbitrary number we've been using for at least a few years
 # specifies that at least 80% of corridor by length must have _some_ data
 minimumCoverageThreshold = 0.8
@@ -13,8 +15,6 @@ def createDynamicBins(obs_df, links_df):
         [starting bin number, ending bin number] ... i.e. both are inclusive
     returns a list of bins
     """
-
-    minLength = links_df['length'].sum() * minimumCoverageThreshold
 
     # start with empty list of bins
     dynamicBins = list()
@@ -41,25 +41,47 @@ def createDynamicBins(obs_df, links_df):
     return dynamicBins
 
 class FiveMinBin:
-    def _init__(self, dt, binNum, linkdirs):
+    def __init__(self, dt, binNum, linkdirs):
         self.dt = dt
         self.binNum = binNum
         self.linkdirs = set(linkdirs)
+    @property
+    def date(self):
+        return self.dt
+    @property
+    def linksdirs(self):
+        return self.linkdirs
 
 class DynamicBin:
     def __init__(self, links):
         self.corridorLinks = links
         self.subBins = list()
-    
+        self.minLength = links['length'].sum() * minimumCoverageThreshold
+
     def extendTo(self, newBin):
         # remove any prior bins from a different date
-        self.subBins = [ b for b in self.subBins if b.dt == newBin.dt ]
+        self.subBins = [
+            b for b in self.subBins
+            if b.date == newBin.date
+        ]
         # remove any prior bins from too long ago
-        self.subBins = [ b for b in self.subBins if b.binNum >= newBin.binNum - maxBinsPerDynamicBin ]
+        self.subBins = [ 
+            b for b in self.subBins
+            if b.binNum >= newBin.binNum - maxBinsPerDynamicBin
+        ]
         # finally, add the new bin
         self.subBins.append(newBin)
 
     @property
     def isComplete(self):
-        pass
-        # TODO: check length of the distinct links in subBins against threshold
+        # check length of the distinct links in sub-bins against threshold
+        uniqueLinkdirs = set(
+            linkdir
+            for bin in self.subBins
+            for linkdir in bin.linkdirs
+        )
+        links = self.corridorLinks.filter(
+            polars.col('link_dir').is_in(uniqueLinkdirs)
+        )
+        lengthSoFar = links['length'].sum()
+        return lengthSoFar >= self.minLength

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -1,13 +1,6 @@
 import polars
-
-# arbitrary number we've been using for at least a few years
-# specifies that at least 80% of corridor by length must have _some_ data
-minimumCoverageThreshold = 0.8
-
-# how long can a dynamic bin get?
-maximumBinLengthMinutes = 30
-nativeBinSizeMinutes = 5
-maxBinsPerDynamicBin = maximumBinLengthMinutes / nativeBinSizeMinutes
+from app.travel_times.FiveMinBin import FiveMinBin
+from app.travel_times.DynamicBin import DynamicBin
 
 def createDynamicBins(obs_df, links_df):
     """Create the smallest temporal bins possible while ensuring data coverage
@@ -39,93 +32,3 @@ def createDynamicBins(obs_df, links_df):
             dynamicBins.append(dynamicBin)
             dynamicBin = DynamicBin(links_df)
     return dynamicBins
-
-class FiveMinBin:
-    def __init__(self, dt, binNum, times_df):
-        self.dt = dt
-        self.binNum = binNum
-        self.linkdirs = set(times_df['link_dir'])
-        self.times = times_df
-    @property
-    def date(self):
-        return self.dt
-    @property
-    def linksdirs(self):
-        return self.linkdirs
-    @property
-    def linkTravelTimes(self):
-        return self.times
-
-class DynamicBin:
-    def __init__(self, links):
-        self.corridorLinks = links
-        self.subBins = list()
-        self.totalLength = links['length'].sum()
-
-    @property
-    def minLength(self):
-        return self.totalLength * minimumCoverageThreshold
-
-    def extendTo(self, newBin):
-        # remove any prior bins from a different date
-        self.subBins = [
-            b for b in self.subBins
-            if b.date == newBin.date
-        ]
-        # remove any prior bins from too long ago
-        self.subBins = [ 
-            b for b in self.subBins
-            if b.binNum >= newBin.binNum - maxBinsPerDynamicBin
-        ]
-        # finally, add the new bin
-        self.subBins.append(newBin)
-
-    @property
-    def isComplete(self):
-        # check length of the distinct links in sub-bins against threshold
-        uniqueLinkdirs = set(
-            linkdir
-            for bin in self.subBins
-            for linkdir in bin.linkdirs
-        )
-        links = self.corridorLinks.filter(
-            polars.col('link_dir').is_in(uniqueLinkdirs)
-        )
-        lengthSoFar = links['length'].sum()
-        return lengthSoFar >= self.minLength
-
-    @property
-    def travelTime(self):
-        extrapolatedTravelTime = polars.concat(
-            [bin.linkTravelTimes for bin in self.subBins]
-        ).join(
-            self.corridorLinks,
-            on='link_dir'
-        ).group_by(
-            ['link_dir','length']
-        ).agg(
-            polars.col('travelTime').mean().alias('link_avg_tt')
-        ).select(
-            polars.col('link_avg_tt').sum().alias('totalObservedTravelTime'),
-            polars.col('length').sum().alias('totalObservedLength')
-        ).select(
-            ( # extrapolate over missing data within each hour
-                polars.col('totalObservedTravelTime') * self.totalLength / polars.col('totalObservedLength')
-            ).alias('extrapolatedTravelTime')
-        ).item()
-
-        return extrapolatedTravelTime
-
-    @property
-    def dates(self):
-        # intending this to wrap dates eventually, thus allowing mutliples 
-        return set( bin.date for bin in self.subBins)
-    
-    @property
-    def date(self):
-        # simple implementation for now
-        return self.subBins[0].date
-
-    @property
-    def length(self):
-        return len(self.subBins)

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -20,32 +20,35 @@ def createDynamicBins(obs_df, links_df):
     dynamicBins = list()
 
     bins5min = obs_df.sql("""
-        SELECT
+        SELECT DISTINCT
             dt,
-            bin_num,
-            ARRAY_AGG(DISTINCT link_dir)
+            bin_num
         FROM self
-        GROUP BY dt, bin_num
         ORDER BY bin_num
     """)
 
     dynamicBin = DynamicBin(links_df)
 
-    for dt, binNum, linkdirs in bins5min.iter_rows():
+    for dt, binNum in bins5min.iter_rows():
+        binData = obs_df.filter(polars.col('bin_num') == binNum).select(['link_dir','travelTime'])
         dynamicBin.extendTo(
-            FiveMinBin(dt, binNum, linkdirs)
+            FiveMinBin(dt, binNum, binData)
         )
         if dynamicBin.isComplete:
             # stash the current one and start a new dynamic bin
             dynamicBins.append(dynamicBin)
             dynamicBin = DynamicBin(links_df)
+    #print([(bin.length, bin.dates) for bin in dynamicBins])
+
     return dynamicBins
 
 class FiveMinBin:
-    def __init__(self, dt, binNum, linkdirs):
+    def __init__(self, dt, binNum, speeds_df):
         self.dt = dt
         self.binNum = binNum
-        self.linkdirs = set(linkdirs)
+        self.linkdirs = set(speeds_df['link_dir'])
+        self.speeds = speeds_df
+
     @property
     def date(self):
         return self.dt
@@ -90,7 +93,7 @@ class DynamicBin:
     @property
     def dates(self):
         return set( bin.date for bin in self.subBins)
-    
+
     @property
     def length(self):
         return len(self.subBins)

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -6,9 +6,7 @@ def createDynamicBins(obs_df, links_df):
     """Iteratively create dynamic bins by accumulating 5-minute data"""
 
     bins5min = obs_df.sql("""
-        SELECT DISTINCT
-            dt,
-            bin_num
+        SELECT DISTINCT bin_num
         FROM self
         ORDER BY bin_num
     """)
@@ -18,12 +16,12 @@ def createDynamicBins(obs_df, links_df):
     # list for accumulating results
     dynamicBins = list()
 
-    for dt, binNum in bins5min.iter_rows():
+    for binNum, in bins5min.iter_rows():
         binData = obs_df.filter(
             polars.col('bin_num') == binNum
         ).select(['link_dir','travelTime'])
         dynamicBin.extendTo(
-            FiveMinBin(dt, binNum, binData)
+            FiveMinBin(binNum, binData)
         )
         if dynamicBin.isComplete:
             # stash the current one and start a new dynamic bin

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -3,14 +3,7 @@ from app.travel_times.FiveMinBin import FiveMinBin
 from app.travel_times.DynamicBin import DynamicBin
 
 def createDynamicBins(obs_df, links_df):
-    """Create the smallest temporal bins possible while ensuring data coverage
-    Defines bins by
-        [starting bin number, ending bin number] ... i.e. both are inclusive
-    returns a list of bins
-    """
-
-    # start with empty list of bins
-    dynamicBins = list()
+    """Iteratively create dynamic bins by accumulating 5-minute data"""
 
     bins5min = obs_df.sql("""
         SELECT DISTINCT
@@ -20,10 +13,15 @@ def createDynamicBins(obs_df, links_df):
         ORDER BY bin_num
     """)
 
+    # create first bin before startng iteration
     dynamicBin = DynamicBin(links_df)
+    # list for accumulating results
+    dynamicBins = list()
 
     for dt, binNum in bins5min.iter_rows():
-        binData = obs_df.filter(polars.col('bin_num') == binNum).select(['link_dir','travelTime'])
+        binData = obs_df.filter(
+            polars.col('bin_num') == binNum
+        ).select(['link_dir','travelTime'])
         dynamicBin.extendTo(
             FiveMinBin(dt, binNum, binData)
         )

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -17,9 +17,49 @@ def createDynamicBins(obs_df, links_df):
     minLength = links_df['length'].sum() * minimumCoverageThreshold
 
     # start with empty list of bins
-    bins = list()
+    dynamicBins = list()
 
-    print(obs_df.select(['dt','bin_num']).unique().sort(['dt','bin_num']))
+    bins5min = obs_df.sql("""
+        SELECT
+            dt,
+            bin_num,
+            ARRAY_AGG(DISTINCT link_dir)
+        FROM self
+        GROUP BY dt, bin_num
+    """)
 
+    dynamicBin = DynamicBin(links_df)
 
-    return None
+    for dt, binNum, linkdirs in bins5min.iter_rows():
+        dynamicBin.extendTo(
+            FiveMinBin(dt, binNum, linkdirs)
+        )
+        if dynamicBin.isComplete:
+            # stash the current one and start a new dynamic bin
+            dynamicBins.append(dynamicBin)
+            dynamicBin = DynamicBin(links_df)
+    return dynamicBins
+
+class FiveMinBin:
+    def _init__(self, dt, binNum, linkdirs):
+        self.dt = dt
+        self.binNum = binNum
+        self.linkdirs = set(linkdirs)
+
+class DynamicBin:
+    def __init__(self, links):
+        self.corridorLinks = links
+        self.subBins = list()
+    
+    def extendTo(self, newBin):
+        # remove any prior bins from a different date
+        self.subBins = [ b for b in self.subBins if b.dt == newBin.dt ]
+        # remove any prior bins from too long ago
+        self.subBins = [ b for b in self.subBins if b.binNum >= newBin.binNum - maxBinsPerDynamicBin ]
+        # finally, add the new bin
+        self.subBins.append(newBin)
+
+    @property
+    def isComplete(self):
+        pass
+        # TODO: check length of the distinct links in subBins against threshold

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -118,7 +118,13 @@ class DynamicBin:
 
     @property
     def dates(self):
+        # intending this to wrap dates eventually, thus allowing mutliples 
         return set( bin.date for bin in self.subBins)
+    
+    @property
+    def date(self):
+        # simple implementation for now
+        return self.subBins[0].date
 
     @property
     def length(self):

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -26,6 +26,7 @@ def createDynamicBins(obs_df, links_df):
             ARRAY_AGG(DISTINCT link_dir)
         FROM self
         GROUP BY dt, bin_num
+        ORDER BY bin_num
     """)
 
     dynamicBin = DynamicBin(links_df)
@@ -85,3 +86,11 @@ class DynamicBin:
         )
         lengthSoFar = links['length'].sum()
         return lengthSoFar >= self.minLength
+
+    @property
+    def dates(self):
+        return set( bin.date for bin in self.subBins)
+    
+    @property
+    def length(self):
+        return len(self.subBins)

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -38,29 +38,33 @@ def createDynamicBins(obs_df, links_df):
             # stash the current one and start a new dynamic bin
             dynamicBins.append(dynamicBin)
             dynamicBin = DynamicBin(links_df)
-    #print([(bin.length, bin.dates) for bin in dynamicBins])
-
     return dynamicBins
 
 class FiveMinBin:
-    def __init__(self, dt, binNum, speeds_df):
+    def __init__(self, dt, binNum, times_df):
         self.dt = dt
         self.binNum = binNum
-        self.linkdirs = set(speeds_df['link_dir'])
-        self.speeds = speeds_df
-
+        self.linkdirs = set(times_df['link_dir'])
+        self.times = times_df
     @property
     def date(self):
         return self.dt
     @property
     def linksdirs(self):
         return self.linkdirs
+    @property
+    def linkTravelTimes(self):
+        return self.times
 
 class DynamicBin:
     def __init__(self, links):
         self.corridorLinks = links
         self.subBins = list()
-        self.minLength = links['length'].sum() * minimumCoverageThreshold
+        self.totalLength = links['length'].sum()
+
+    @property
+    def minLength(self):
+        return self.totalLength * minimumCoverageThreshold
 
     def extendTo(self, newBin):
         # remove any prior bins from a different date
@@ -89,6 +93,28 @@ class DynamicBin:
         )
         lengthSoFar = links['length'].sum()
         return lengthSoFar >= self.minLength
+
+    @property
+    def travelTime(self):
+        extrapolatedTravelTime = polars.concat(
+            [bin.linkTravelTimes for bin in self.subBins]
+        ).join(
+            self.corridorLinks,
+            on='link_dir'
+        ).group_by(
+            ['link_dir','length']
+        ).agg(
+            polars.col('travelTime').mean().alias('link_avg_tt')
+        ).select(
+            polars.col('link_avg_tt').sum().alias('totalObservedTravelTime'),
+            polars.col('length').sum().alias('totalObservedLength')
+        ).select(
+            ( # extrapolate over missing data within each hour
+                polars.col('totalObservedTravelTime') * self.totalLength / polars.col('totalObservedLength')
+            ).alias('extrapolatedTravelTime')
+        ).item()
+
+        return extrapolatedTravelTime
 
     @property
     def dates(self):

--- a/backend/app/travel_times/dynamic_bins.py
+++ b/backend/app/travel_times/dynamic_bins.py
@@ -1,0 +1,27 @@
+import pandas
+
+# arbitrary number we've been using for at least a few years
+# specifies that at least 80% of corridor by length must have _some_ data
+minimumCoverageThreshold = 0.8
+
+# how long can a dynamic bin get?
+maximumBinLengthMinutes = 30
+nativeBinSizeMinutes = 5
+maxBinsPerDynamicBin = maximumBinLengthMinutes / nativeBinSizeMinutes
+
+def createDynamicBins(obs_df, links_df):
+    """Create the smallest temporal bins possible while ensuring data coverage
+    Defines bins by
+        [starting bin number, ending bin number] ... i.e. both are inclusive
+    returns a list of bins
+    """
+
+    minLength = links_df['length'].sum() * minimumCoverageThreshold
+
+    # start with empty list of bins
+    bins = list()
+
+    print(obs_df[['dt','bin_num']].drop_duplicates().sort_values(['dt','bin_num']))
+
+
+    return None

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -8,6 +8,7 @@ from app.travel_times.cache import checkCache, cacheAndReturn
 from app.travel_times.bootstrap import bootstrap
 from app.travel_times.daily_aggregation import mean_daily_mean
 from app.corridors.conflateMapVersions import corridorsAreTheSame
+from app.travel_times.dynamic_bins import createDynamicBins
 import pandas
 
 def makeURI(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list):
@@ -94,9 +95,12 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 link_speeds_df = pandas.DataFrame(
                     cursor.fetchall(),
                     columns=['link_dir','dt','hr','bin_num','speed']
-                ).set_index('link_dir')
+                )
+
+        bins = createDynamicBins(link_speeds_df[['dt','bin_num','link_dir']], links_df)
+
         # join link lengths
-        link_speeds_df = link_speeds_df.join(links_df)
+        link_speeds_df = link_speeds_df.join(links_df,on='link_dir')
         # calculate link travel times from speed and length (in seconds)
         link_speeds_df['tt'] = link_speeds_df['length'] / link_speeds_df['speed'] * 3.6
         # no longer need speeds now that this is measured in terms of travel time

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -43,7 +43,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             link_dir,
             dt::text,
             extract(HOUR FROM tod)::smallint AS hr,
-            (extract('EPOCH' FROM tod)::int / (5 * 60))::smallint AS bin_num,
+            EXTRACT('EPOCH' FROM dt + tod)::int / (5 * 60) AS bin_num,
             mean::real AS speed_kmph
         FROM here.ta_path
         WHERE

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -113,7 +113,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         )
 
         observations = polars.DataFrame({
-            'dt': [bin.date for bin in dynamicBins],
+            'dt': [bin.singleDate for bin in dynamicBins],
             'tt': [bin.travelTime for bin in dynamicBins]
         })
 

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -41,7 +41,6 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     query = f'''
         SELECT
             link_dir,
-            dt::text,
             EXTRACT('EPOCH' FROM dt + tod)::int / (5 * 60) AS bin_num,
             mean::real AS speed_kmph
         FROM here.ta_path
@@ -95,7 +94,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 link_speeds_df = polars.DataFrame(
                     cursor.fetchall(),
                     orient='row',
-                    schema=['link_dir','dt','bin_num','speed']
+                    schema=['link_dir','bin_num','speed']
                 )
 
         # join link lengths and
@@ -103,12 +102,12 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         link_times_df = link_speeds_df.join(
             links_df, on='link_dir'
         ).select( [
-            'link_dir', 'dt', 'bin_num', 'length',
+            'link_dir', 'bin_num', 'length',
             (polars.col('length') / polars.col('speed') * 3.6).alias('travelTime')
         ] )
 
         dynamicBins = createDynamicBins(
-            link_times_df.select(['link_dir','dt','bin_num','travelTime']),
+            link_times_df.select(['link_dir','bin_num','travelTime']),
             links_df
         )
 

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -113,20 +113,10 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             links_df
         )
 
-        # get average travel times per link / date / hour
-        observations = link_times_df.group_by(['link_dir','dt','hr','length']).agg(
-            polars.col('travelTime').mean().alias('link_avg_tt')
-        ).group_by(['dt', 'hr']).agg( # sum lengths and times of available links per bin
-            polars.col('link_avg_tt').sum().alias('total_tt'),
-            polars.col('length').sum().alias('total_length')
-        ).filter( # filter out hours with too much missing data
-            polars.col('total_length') / total_corridor_length >= 0.8
-        ).select( [
-            'dt', 'hr',
-            ( # extrapolate over missing data within each hour
-                polars.col('total_tt') * total_corridor_length / polars.col('total_length')
-            ).alias('tt_extrapolated')
-        ] )
+        observations = polars.DataFrame({
+            'dt': [bin.date for bin in dynamicBins],
+            'tt': [bin.travelTime for bin in dynamicBins]
+        })
 
         try:
             # append observations from this map version
@@ -139,7 +129,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
 
     # convert to format that can be used by the same summary function
     sample = []
-    for dt, hr, tt in observationsAllVersions.iter_rows():
+    for dt, tt in observationsAllVersions.iter_rows():
         sample.append((dt, tt))
 
     if len(sample) < 1:

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -42,7 +42,6 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         SELECT
             link_dir,
             dt::text,
-            extract(HOUR FROM tod)::smallint AS hr,
             EXTRACT('EPOCH' FROM dt + tod)::int / (5 * 60) AS bin_num,
             mean::real AS speed_kmph
         FROM here.ta_path
@@ -96,7 +95,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 link_speeds_df = polars.DataFrame(
                     cursor.fetchall(),
                     orient='row',
-                    schema=['link_dir','dt','hr','bin_num','speed']
+                    schema=['link_dir','dt','bin_num','speed']
                 )
 
         # join link lengths and
@@ -104,7 +103,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
         link_times_df = link_speeds_df.join(
             links_df, on='link_dir'
         ).select( [
-            'link_dir', 'dt', 'hr', 'bin_num', 'length',
+            'link_dir', 'dt', 'bin_num', 'length',
             (polars.col('length') / polars.col('speed') * 3.6).alias('travelTime')
         ] )
 

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -99,19 +99,23 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                     schema=['link_dir','dt','hr','bin_num','speed']
                 )
 
-        bins = createDynamicBins(link_speeds_df[['dt','bin_num','link_dir']], links_df)
-
         # join link lengths and
         # calculate link travel times from speed and length (in seconds)
-        link_speeds_df = link_speeds_df.join(
+        link_times_df = link_speeds_df.join(
             links_df, on='link_dir'
         ).select( [
-            'link_dir', 'dt', 'hr', 'length',
-            (polars.col('length') / polars.col('speed') * 3.6).alias('link_tt')
+            'link_dir', 'dt', 'hr', 'bin_num', 'length',
+            (polars.col('length') / polars.col('speed') * 3.6).alias('travelTime')
         ] )
+
+        dynamicBins = createDynamicBins(
+            link_times_df.select(['link_dir','dt','bin_num','travelTime']),
+            links_df
+        )
+
         # get average travel times per link / date / hour
-        observations = link_speeds_df.group_by(['link_dir','dt','hr','length']).agg(
-            polars.col('link_tt').mean().alias('link_avg_tt')
+        observations = link_times_df.group_by(['link_dir','dt','hr','length']).agg(
+            polars.col('travelTime').mean().alias('link_avg_tt')
         ).group_by(['dt', 'hr']).agg( # sum lengths and times of available links per bin
             polars.col('link_avg_tt').sum().alias('total_tt'),
             polars.col('length').sum().alias('total_length')

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -128,9 +128,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             observationsAllVersions = observations
 
     # convert to format that can be used by the same summary function
-    sample = []
-    for dt, tt in observationsAllVersions.iter_rows():
-        sample.append((dt, tt))
+    sample = [ (dt, tt) for dt, tt in observationsAllVersions.iter_rows() ]
 
     if len(sample) < 1:
         # no travel times or related info to return here

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -42,6 +42,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             link_dir,
             dt::text,
             extract(HOUR FROM tod)::smallint AS hr,
+            (extract('EPOCH' FROM tod)::int / (5 * 60))::smallint AS bin_num,
             mean::real AS speed_kmph
         FROM here.ta_path
         WHERE
@@ -92,7 +93,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 cursor.execute(query, query_params)
                 link_speeds_df = pandas.DataFrame(
                     cursor.fetchall(),
-                    columns=['link_dir','dt','hr','speed']
+                    columns=['link_dir','dt','hr','bin_num','speed']
                 ).set_index('link_dir')
         # join link lengths
         link_speeds_df = link_speeds_df.join(links_df)

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -62,6 +62,8 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
     if len(hereMaps) > 1 and not corridorsAreTheSame(start_node, end_node, hereMaps):
         return {'error': 'corridor changed somehow between map versions'}
 
+    observations = list()
+
     for hereMap in hereMaps:
         links, corridorURI = get_here_links(start_node, end_node, hereMap['version'])
         links_df = polars.DataFrame({
@@ -111,31 +113,16 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             links_df
         )
 
-        observations = polars.DataFrame({
-            'dt': [bin.singleDate for bin in dynamicBins],
-            'tt': [bin.travelTime for bin in dynamicBins]
-        })
+        observations += dynamicBins
 
-        try:
-            # append observations from this map version
-            # (try, because it's not defined yet on the first pass)
-            observationsAllVersions = polars.concat(
-                [observations, observationsAllVersions]
-            )
-        except:
-            observationsAllVersions = observations
-
-    # convert to format that can be used by the same summary function
-    sample = [ (dt, tt) for dt, tt in observationsAllVersions.iter_rows() ]
-
-    if len(sample) < 1:
+    if len(observations) < 1:
         # no travel times or related info to return here
         return cacheAndReturn({
             'results': {
                 'travel_time': None,
                 'observations': [],
                 'confidence': {
-                    'sample': len(sample) # 0
+                    'sample': len(observations) # 0
                 },
             },
             'query': {
@@ -149,12 +136,12 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
 
     return cacheAndReturn({
         'results': {
-            'travel_time': timeFormats(mean_daily_mean(sample),1),
+            'travel_time': timeFormats(mean_daily_mean(observations),1),
             'confidence': {
-                'sample': len(sample),
-                'intervals': bootstrap(sample)
+                'sample': len(observations),
+                'intervals': bootstrap(observations)
             },
-            'observations': [timeFormats(tt,1) for (dt,tt) in sample]
+            'observations': [timeFormats(bin.travelTime,1) for bin in observations]
         },
         'query': {
             'corridor': {


### PR DESCRIPTION
This is a reimplementation of https://github.com/CityofToronto/bdit_tt_request_app/pull/128 and https://github.com/CityofToronto/bdit_tt_request_app/pull/192 following some fairly major upstream changes to `deploy`. See [here](https://github.com/CityofToronto/bdit_tt_request_app/pull/128#issue-2399307274) for a gist of the changes.

Resolves #143 and resolves #223.

This creates dynamic bins with a maximum length of 30 minutes (6 5-minute bins).

Bins can extend past midnight, if the timerange does, but the earlier of the two dates will be used for the aggregation. 