### PR TITLE
Return observed percentiles of travel times

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
                 "@emotion/react": "^11.10.6",
                 "@emotion/styled": "^11.10.6",
                 "@mui/material": "5.x",
+                "d3-array": "^3.2.4",
                 "express": "^4.18.2",
                 "maplibre-gl": "4.7.x",
                 "p-queue": "^8.0.1",
@@ -3745,6 +3746,18 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -5541,6 +5554,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/interpret": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@mui/material": "5.x",
+        "d3-array": "^3.2.4",
         "express": "^4.18.2",
         "maplibre-gl": "4.7.x",
         "p-queue": "^8.0.1",

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -1,4 +1,5 @@
 import { domain } from './domain.js'
+import { quantile } from 'd3-array'
 
 export class TravelTimeQuery {
     #corridor
@@ -112,7 +113,21 @@ export class TravelTimeQuery {
         // turning these off in the frontend until they're ready for production
         //record.set('moe_lower_p95', this.#results?.confidence?.intervals?.['p=0.95']?.lower?.seconds)
         //record.set('moe_upper_p95', this.#results?.confidence?.intervals?.['p=0.95']?.upper?.seconds)
-
+        record.set('n', this.#results.observations.length)
+        record.set(
+            '95th percentile (seconds)',
+            quantile(
+                this.#results.observations.map(obs => obs.seconds),
+                0.95
+            )
+        )
+        record.set(
+            '5th percentile (seconds)',
+            quantile(
+                this.#results.observations.map(obs => obs.seconds),
+                0.05
+            )
+        )
         if(type=='json'){
             return Object.fromEntries(record) // can't JSONify maps
         }else if(type=='csv'){

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -113,18 +113,18 @@ export class TravelTimeQuery {
         // turning these off in the frontend until they're ready for production
         //record.set('moe_lower_p95', this.#results?.confidence?.intervals?.['p=0.95']?.lower?.seconds)
         //record.set('moe_upper_p95', this.#results?.confidence?.intervals?.['p=0.95']?.upper?.seconds)
-        record.set('n', this.#results.observations.length)
+        record.set('n', this.#results?.observations?.length)
         record.set(
             '95th percentile (seconds)',
             quantile(
-                this.#results.observations.map(obs => obs.seconds),
+                this.#results?.observations?.map(obs => obs.seconds) ?? [],
                 0.95
             )
         )
         record.set(
             '85th percentile (seconds)',
             quantile(
-                this.#results.observations.map(obs => obs.seconds),
+                this.#results?.observations?.map(obs => obs.seconds) ?? [],
                 0.85
             )
         )

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -122,10 +122,10 @@ export class TravelTimeQuery {
             )
         )
         record.set(
-            '5th percentile (seconds)',
+            '85th percentile (seconds)',
             quantile(
                 this.#results.observations.map(obs => obs.seconds),
-                0.05
+                0.85
             )
         )
         if(type=='json'){


### PR DESCRIPTION
Adds the 85th and 95th observed travel time percentiles to the output. Percentiles may be interpolated between adjacent observations. 

This will likely not be merged, but was needed for a request: https://github.com/Toronto-Big-Data-Innovation-Team/rapidto/issues/92