### PR TITLE
Be explicit about polars dataframe data types

### DIFF
--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -101,7 +101,11 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 link_speeds_df = polars.DataFrame(
                     cursor.fetchall(),
                     orient='row',
-                    schema=['link_dir','bin_num','speed']
+                    schema={
+                        'link_dir': polars.String,
+                        'bin_num': polars.Int32,
+                        'speed': polars.Float32
+                    }
                 )
 
         # join link lengths and


### PR DESCRIPTION
Resolves #245

This prevents an error resulting from the data type being null where there is nothing returned from the speeds/times query.

By setting these explicitly, we let that join go forward with no data in the dataframe to join to. 