### PR TITLE
Omit irrelevant queries WRT holidays

### DIFF
--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -119,15 +119,21 @@ export class SpatialData {
                 this.dateRanges.filter(dr=>dr.isComplete).forEach( dateRange => {
                     this.days.filter(d=>d.isComplete).forEach( days => {
                         this.holidayOptions.forEach( holidayOption => {
-                            crossProduct.push(
-                                new TravelTimeQuery({
-                                    corridor,
-                                    timeRange,
-                                    dateRange,
-                                    days,
-                                    holidayOption
-                                })
-                            )
+                            const ttq = new TravelTimeQuery({
+                                corridor,
+                                timeRange,
+                                dateRange,
+                                days,
+                                holidayOption
+                            })
+                            if(
+                                this.holidayOptions.length > 1 // "do it both ways"
+                                && holidayOption.holidaysIncluded // included for this one
+                                && !ttq.holidaysAreRelevant // but it's not relevant
+                            ){ // only the no-holidays version of this will be queried
+                                return
+                            }
+                            crossProduct.push(ttq)
                         } )
                     } )
                 } )


### PR DESCRIPTION
Resolves #137

In the cross-product build-out of travel time queries, this adds a step checking if
* both holiday options are selected
* holidays are included in this particular query
* but also they're not relevant

And excludes those.

This means we never query the option where holidays are included but not relevant. All holiday-irrelevant date ranges will have the holiday option set to false in the URI, but the holidays column in the output will still be marked as NA.

Here's an example: 
[results.csv](https://github.com/user-attachments/files/25949407/results.csv)

(previously this would have had eight results, two of them redundant)