### PR TITLE
Indicate corridor orientation visually

### DIFF
--- a/frontend/src/Sidebar/sidebar.css
+++ b/frontend/src/Sidebar/sidebar.css
@@ -71,18 +71,34 @@
     margin-left: 10px;
 }
 
+.factor .corridorName {
+    display: flex;
+}
+
 .factor .corridorName.Northbound::before {
     content: '\2191';
+    font-weight: bold;
+    font-size: 1.5em;
+    margin-right: 5px;
 }
 
 .factor .corridorName.Southbound::before {
     content: '\2193';
+    font-weight: bold;
+    font-size: 1.5em;
+    margin-right: 5px;
 }
 
 .factor .corridorName.Eastbound::before {
     content: '\2192';
+    font-weight: bold;
+    font-size: 1.5em;
+    margin-right: 5px;
 }
 
 .factor .corridorName.Westbound::before {
     content: '\2190';
+    font-weight: bold;
+    font-size: 1.5em;
+    margin-right: 5px;
 }

--- a/frontend/src/Sidebar/sidebar.css
+++ b/frontend/src/Sidebar/sidebar.css
@@ -70,3 +70,19 @@
     float: right;
     margin-left: 10px;
 }
+
+.factor .corridorName.Northbound::before {
+    content: '\2191';
+}
+
+.factor .corridorName.Southbound::before {
+    content: '\2193';
+}
+
+.factor .corridorName.Eastbound::before {
+    content: '\2192';
+}
+
+.factor .corridorName.Westbound::before {
+    content: '\2190';
+}

--- a/frontend/src/corridor.js
+++ b/frontend/src/corridor.js
@@ -153,7 +153,7 @@ export class Corridor extends Factor {
 function CorridorElement({corridor}){
     return (
         <div>
-            <div className='corridorName'>
+            <div className={`corridorName ${corridor.bearing}`}>
                 {corridor.name}
             </div>
             {corridor.isActive && <>

--- a/frontend/src/corridor.js
+++ b/frontend/src/corridor.js
@@ -154,7 +154,7 @@ function CorridorElement({corridor}){
     return (
         <div>
             <div className={`corridorName ${corridor.bearing}`}>
-                {corridor.name}
+                <div>{corridor.name}</div>
             </div>
             {corridor.isActive && <>
                 <div className='instructions'>


### PR DESCRIPTION
<img width="325" height="344" alt="Screenshot 2026-03-19 at 15-31-19 Travel Time Request App" src="https://github.com/user-attachments/assets/3b7598ba-26d7-4fe0-9113-883eb3228bb1" />

Lists of corridors can be really hard to scan to find something particular. This should help them to scan easier. A small thing to be sure, but should help. 