### PR TITLE
Enable exclusion of specified dates from date ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When you [visit the app](https://trans-bdit.intra.prod-toronto.ca/traveltime-req
 | ----- | ----------- |
 | Corridor | Drawn on the map, it is a shortest path between two intersections of your choice. Draw it in both directions if you need both directions of travel. Be cautious about drawing corridors longer than a couple of kilometers, as the aggregation methods are not well tested for very long corridors. |
 | Time Range | Times must start and end on the hour and the app accepts integer values between 0 and 24. The final hour is _exclusive_, meaning that a range of 7am to 9am covers two hours, not three. Values of 0 and 24 both interchangeably represent midnight; a time range of 0 - 24 will return all hours of the day. A time range starting after it ends (e.g. 10pm to 4am) will wrap around midnight[^1]. |
-| Date Range | Use the calendar widget to select a date range. Note that selected ranges are displayed with an exclusive end date. |
+| Date Range | Use the calendar widget to select a date range. Note that selected ranges are displayed with an exclusive end date. Once created, there is an option to exclude one or more specific dates from the range. |
 | Day of Week | Identify the days of week to include in the aggregation. |
 | Holiday Inclusion | Decide whether to include or exclude Ontario's statutory holidays if applicable. You can also opt to do it both ways. |
 
@@ -39,7 +39,7 @@ The app can return results in either CSV or JSON format. The fields in either ca
 | `startCrossStreets` | The names of any cross-street(s) at the start of the corridor. If the corridor starts mid-block then coordinates of that point will be returned instead. |
 | `endCrossStreets` | The names of any cross-street(s) at the end of the corridor. If the corridor ends mid-block then coordinates of that point will be returned instead. |
 | `timeRange` | Text description of the time-of-day range included in the query. |
-| `dateRange` | Text description of the range of dates included in the query. |
+| `dateRange` | Text description of the range of dates included in the query. If this includes an asterisk, please see the `notes` field for excluded dates. |
 | `daysOfWeek` | Text description of the days of week included in the query.  |
 | `holidaysIncluded` | Boolean, indicating if statutory holidays where (True) or were not (False) included in the query. If there are no holidays within the date range, will return `NA`. |
 | `hoursInRange` | The total number of hours that are theoretically within the scope of the query's various parameters. This does not imply that data is/was available at all times. It's possible to construct requests with zero hours in range such as e.g `2023-01-01` to `2023-01-02`, Mondays only (There's only one Sunday in that range). Impossible combinations are included in the output for clarity and completeness but are not actually executed against the API and should return an error. |

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -167,6 +167,7 @@ def aggregate_travel_times(
     include_holidays (str, boolean): 'true' will include holidays, 'false' will exclude them if applicable
     dow_list (str): concatenated list of integers representing days of week to be included; ISODOW specification. E.g. [6,7] -> '67' for Saturday and Sunday only.
     optional GET arg 'noCache' bypasses any cached results
+    optional GET arg 'excludeDates' gives dates in YYYY-MM-DD format to exclude
     """
     try:
         start_node = int(start_node)
@@ -192,6 +193,10 @@ def aggregate_travel_times(
     dow_list = list(set([int(numstr) for numstr in re.findall(r"[1-7]", dow_str)]))
     if len(dow_list) == 0:
         return jsonify({'error': "dow list does not contain valid characters, i.e. [1-7]"})
+
+    if request.args.get('excludeDates') is not None:
+        excludeDates = re.findall(r"\d{4}-\d{2}-\d{2}", request.args.get('excludeDates'))
+        print(excludeDates)
 
     return jsonify(
         get_travel_time(

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -194,9 +194,15 @@ def aggregate_travel_times(
     if len(dow_list) == 0:
         return jsonify({'error': "dow list does not contain valid characters, i.e. [1-7]"})
 
-    if request.args.get('excludeDates') is not None:
-        excludeDates = re.findall(r"\d{4}-\d{2}-\d{2}", request.args.get('excludeDates'))
-        print(excludeDates)
+    excludeDates = []
+    if request.args.get('excludeDates') is not None: 
+        for dateString in re.findall(r"\d{4}-\d{2}-\d{2}", request.args.get('excludeDates')):
+            try:
+                # parse date to verify but then just store the string
+                datetime.strptime(dateString, "%Y-%m-%d")
+                excludeDates.append(dateString)
+            except:
+                pass
 
     return jsonify(
         get_travel_time(
@@ -205,7 +211,8 @@ def aggregate_travel_times(
             start_date, end_date,
             include_holidays,
             dow_list,
-            noCache = request.args.get('noCache') is not None
+            noCache = request.args.get('noCache') is not None,
+            excludeDates = excludeDates
         )
     )
 

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -17,7 +17,7 @@ def makeURI(start_node, end_node, start_time, end_time, start_date, end_date, in
     URI += f'/{str(include_holidays).lower()}/{"".join(map(str,dow_list))}'
     return URI
 
-def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, noCache=False, excludedDates=[]):
+def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, noCache=False, excludeDates=[]):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
     # first check the cache
     cacheURI = makeURI(
@@ -53,6 +53,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             AND date_part('ISODOW', dt) = ANY(%(dow_list)s)
             AND dt >= %(start_date)s::date
             AND dt < %(end_date)s::date
+            AND dt != ANY(%(excludedDates)s)
             {holiday_clause}
     '''
     # always possible that this spans a map version change
@@ -93,7 +94,8 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
                 # TODO: Y3K problem
                 hereMap['upperDateExclusive'] if hereMap['upperDateExclusive'] else '3000-01-01'
             ),
-            "dow_list": dow_list
+            "dow_list": dow_list,
+            "excludedDates": excludeDates
         }
         with pool.connection() as connection:
             with connection.cursor() as cursor:

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -17,7 +17,7 @@ def makeURI(start_node, end_node, start_time, end_time, start_date, end_date, in
     URI += f'/{str(include_holidays).lower()}/{"".join(map(str,dow_list))}'
     return URI
 
-def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, noCache=False):
+def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_date, include_holidays, dow_list, noCache=False, excludedDates=[]):
     """Function for returning data from the aggregate-travel-times/ endpoint"""
     # first check the cache
     cacheURI = makeURI(

--- a/backend/app/travel_times/get_travel_time.py
+++ b/backend/app/travel_times/get_travel_time.py
@@ -35,6 +35,10 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             SELECT 1 FROM ref.holiday WHERE ta_path.dt = holiday.dt
         )'''
 
+    excludedDatesClause = ''
+    if len(excludeDates) > 0:
+        excludedDatesClause = 'AND dt != ANY(%(excludedDates)s)'
+
     # if end_time is less than the start_time, then we wrap around midnight
     ToD_and_or = 'AND' if end_time > start_time else 'OR'
 
@@ -53,7 +57,7 @@ def get_travel_time(start_node, end_node, start_time, end_time, start_date, end_
             AND date_part('ISODOW', dt) = ANY(%(dow_list)s)
             AND dt >= %(start_date)s::date
             AND dt < %(end_date)s::date
-            AND dt != ANY(%(excludedDates)s)
+            {excludedDatesClause}
             {holiday_clause}
     '''
     # always possible that this spans a map version change

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -1,7 +1,7 @@
 import { Intersection } from '../intersection.js'
 import { domain } from '../domain.js'
 
-const TTURIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})\/(?<holidays>true|false)\/(?<dow>\d+)/g
+const TTURIpattern = /\/(?<startNode>\d+)\/(?<endNode>\d+)\/(?<startTime>\d+)\/(?<endTime>\d+)\/(?<startDate>\d{4}-\d{2}-\d{2})\/(?<endDate>\d{4}-\d{2}-\d{2})\/(?<holidays>true|false)\/(?<dow>\d+)\??(noCache)?&?(excludeDates=(?<excludedDates>(\d{4}-\d{2}-\d{2},?)+))?/g
 const CorridorURIpattern = /\/link-nodes\/here\/(?<startNode>\d+)\/(?<endNode>\d+)/g
 
 export async function restoreStateFromFile(fileDropEvent,stateData,logActivity){
@@ -44,8 +44,9 @@ export async function restoreStateFromFile(fileDropEvent,stateData,logActivity){
                     timeRange.setStartTime(startTime)
                     timeRange.setEndTime(endTime)
                 } )
-            distinctPerProps(URIs,'startDate','endDate')
-                .forEach( ({startDate,endDate}) => {
+            distinctPerProps(URIs,'startDate','endDate','excludedDates')
+                .forEach( ({startDate,endDate,excludedDates}) => {
+                    console.log(excludedDates)
                     let dateRange = stateData.createDateRange()
                     dateRange.setStartDate(new Date(Date.parse(startDate)))
                     dateRange.setEndDate(new Date(Date.parse(endDate)))

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -46,10 +46,20 @@ export async function restoreStateFromFile(fileDropEvent,stateData,logActivity){
                 } )
             distinctPerProps(URIs,'startDate','endDate','excludedDates')
                 .forEach( ({startDate,endDate,excludedDates}) => {
-                    console.log(excludedDates)
+                    console.log('sd',startDate)
                     let dateRange = stateData.createDateRange()
                     dateRange.setStartDate(new Date(Date.parse(startDate)))
                     dateRange.setEndDate(new Date(Date.parse(endDate)))
+                    if(excludedDates){
+                        excludedDates.split(',').map( dateString => {
+                            try {
+                                dateRange.addExcludedDate(                            
+                                    new Date(Date.parse(dateString))
+                                )
+                            } catch { /*do nothing if not parsed as date*/ }
+                        } )
+                        dateRange
+                    }
                 } )
             // holiday inclusion
             let holidays = new Set(URIs.map(uri => uri.holidays))

--- a/frontend/src/Sidebar/restoreStateFromFile.js
+++ b/frontend/src/Sidebar/restoreStateFromFile.js
@@ -46,7 +46,6 @@ export async function restoreStateFromFile(fileDropEvent,stateData,logActivity){
                 } )
             distinctPerProps(URIs,'startDate','endDate','excludedDates')
                 .forEach( ({startDate,endDate,excludedDates}) => {
-                    console.log('sd',startDate)
                     let dateRange = stateData.createDateRange()
                     dateRange.setStartDate(new Date(Date.parse(startDate)))
                     dateRange.setEndDate(new Date(Date.parse(endDate)))

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -136,7 +136,7 @@ function DateRangeElement({dateRange}){
             </> }
             {dateRange.isActive && dateRange.isComplete && <div>
                 {dateRange.hasExclusions && <div>
-                    Excluding
+                    *Excluding:
                     <ul>
                         {dateRange.excludedDates.map((d,i)=>(
                             <li key={i}>
@@ -162,6 +162,7 @@ function DateRangeElement({dateRange}){
                         dateRange.addExcludedDate(date)
                         setAddingDateExclusion(false)
                     }}
+                    activeStartDate={selectedRange[0]}
                     minDate={selectedRange[0]}
                     maxDate={selectedRange[1]}
                 />

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -7,6 +7,7 @@ import { DataContext } from './Layout'
 export class DateRange extends Factor {
     #startDate
     #endDate
+    #excludedDates = new Map()
     #dataContext
     constructor(dataContext){
         super(dataContext)
@@ -19,7 +20,7 @@ export class DateRange extends Factor {
         if(this.#startDate || this.#endDate){
             let start = DateRange.dateFormatted(this.#startDate) ?? '???'
             let end = DateRange.dateFormatted(this.#endDate) ?? '???'
-            return `From ${start} to ${end}`
+            return `From ${start} to ${end}${this.hasExclusions ? '*':''}`
         }
         return 'New Date Range'
     }
@@ -35,6 +36,18 @@ export class DateRange extends Factor {
         this.#endDate = inputDate
         this.hasUpdated()
         return this.#endDate
+    }
+    addExcludedDate(date){
+        this.#excludedDates.set(DateRange.dateFormatted(date), date)
+    }
+    removeExcludedDate(date){
+        this.#excludedDates.delete(DateRange.dateFormatted(date))
+    }
+    get excludedDates(){
+        return [...this.#excludedDates.values().map(DateRange.dateFormatted)]
+    }
+    get hasExclusions(){
+        return this.#excludedDates.size > 0
     }
     static dateFormatted(datetime){
         if(datetime){
@@ -94,7 +107,6 @@ function DateRangeElement({dateRange}){
     const { logActivity } = useContext(DataContext)
     const [ selectedRange, setSelectedRange ] = useState(undefined)
     const [ editing, setEditing ] = useState(true)
-    const [ excludedDates, setExcludedDates ] = useState( [] )
     const [ addingDateExclusion, setAddingDateExclusion ] = useState(false)
     useEffect(()=>{
         if(!selectedRange) return;
@@ -104,18 +116,19 @@ function DateRangeElement({dateRange}){
         setEditing(false)
         logActivity('dateRange selected/updated')
     },[selectedRange])
-    console.log(excludedDates)
+    console.log(dateRange.excludedDates)
     return (
         <div>
             <div className='dateRangeName'>{dateRange.name}</div>
+
             {dateRange.isActive && (editing || ! dateRange.isComplete)&& <>
                 <Calendar
                     value={selectedRange}
                     selectRange={true}
                     allowPartialRange={true}
                     onChange={setSelectedRange}
-                    maxDate={dateRange.maxDate}
                     minDate={dateRange.minDate}
+                    maxDate={dateRange.maxDate}
                 />
             </> }
             {dateRange.isActive && dateRange.isComplete && <div>
@@ -129,7 +142,10 @@ function DateRangeElement({dateRange}){
             </div>}
             {addingDateExclusion && <>
                 <Calendar
-                    onChange={(date)=>{console.log(date);setAddingDateExclusion(false)}}
+                    onChange={(date)=>{
+                        dateRange.addExcludedDate(date)
+                        setAddingDateExclusion(false)
+                    }}
                     minDate={selectedRange[0]}
                     maxDate={selectedRange[1]}
                 />

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -11,6 +11,7 @@ export class DateRange extends Factor {
     constructor(dataContext){
         super(dataContext)
         this.#dataContext = dataContext
+
     }
     get isComplete(){
         return this.#startDate && this.#endDate && this.#startDate < this.#endDate
@@ -103,7 +104,7 @@ function DateRangeElement({dateRange}){
     return (
         <div>
             <div className='dateRangeName'>{dateRange.name}</div>
-            {dateRange.isActive && <>
+            {dateRange.isActive && ! dateRange.isComplete && <>
                 <Calendar
                     value={selectedRange}
                     selectRange={true}

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -11,7 +11,6 @@ export class DateRange extends Factor {
     constructor(dataContext){
         super(dataContext)
         this.#dataContext = dataContext
-
     }
     get isComplete(){
         return this.#startDate && this.#endDate && this.#startDate < this.#endDate
@@ -95,6 +94,8 @@ function DateRangeElement({dateRange}){
     const { logActivity } = useContext(DataContext)
     const [ selectedRange, setSelectedRange ] = useState(undefined)
     const [ editing, setEditing ] = useState(true)
+    const [ excludedDates, setExcludedDates ] = useState( [] )
+    const [ addingDateExclusion, setAddingDateExclusion ] = useState(false)
     useEffect(()=>{
         if(!selectedRange) return;
         let [ start, end ] = selectedRange
@@ -103,6 +104,7 @@ function DateRangeElement({dateRange}){
         setEditing(false)
         logActivity('dateRange selected/updated')
     },[selectedRange])
+    console.log(excludedDates)
     return (
         <div>
             <div className='dateRangeName'>{dateRange.name}</div>
@@ -120,7 +122,18 @@ function DateRangeElement({dateRange}){
                 <small><a onClick={()=>{setEditing(true)}}>
                     Edit date range
                 </a></small>
+                <br/>
+                <small><a onClick={()=>{setAddingDateExclusion(true)}}>
+                    Add date exclusion
+                </a></small>
             </div>}
+            {addingDateExclusion && <>
+                <Calendar
+                    onChange={(date)=>{console.log(date);setAddingDateExclusion(false)}}
+                    minDate={selectedRange[0]}
+                    maxDate={selectedRange[1]}
+                />
+            </>}
         </div>
     )
 }

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -94,17 +94,19 @@ function formatISODate(dt){ // this is waaay too complicated... alas
 function DateRangeElement({dateRange}){
     const { logActivity } = useContext(DataContext)
     const [ selectedRange, setSelectedRange ] = useState(undefined)
+    const [ editing, setEditing ] = useState(true)
     useEffect(()=>{
         if(!selectedRange) return;
         let [ start, end ] = selectedRange
         dateRange.setStartDate(start)
         dateRange.setEndDate(end)
+        setEditing(false)
         logActivity('dateRange selected/updated')
     },[selectedRange])
     return (
         <div>
             <div className='dateRangeName'>{dateRange.name}</div>
-            {dateRange.isActive && ! dateRange.isComplete && <>
+            {dateRange.isActive && (editing || ! dateRange.isComplete)&& <>
                 <Calendar
                     value={selectedRange}
                     selectRange={true}
@@ -114,6 +116,11 @@ function DateRangeElement({dateRange}){
                     minDate={dateRange.minDate}
                 />
             </> }
+            {dateRange.isActive && dateRange.isComplete && <div>
+                <small><a onClick={()=>{setEditing(true)}}>
+                    Edit date range
+                </a></small>
+            </div>}
         </div>
     )
 }

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -41,7 +41,11 @@ export class DateRange extends Factor {
         this.#excludedDates.set(DateRange.dateFormatted(date), date)
     }
     removeExcludedDate(date){
-        this.#excludedDates.delete(DateRange.dateFormatted(date))
+        if(date instanceof Date){
+            this.#excludedDates.delete(DateRange.dateFormatted(date))
+        } else {
+            this.#excludedDates.delete(date)
+        }
     }
     get excludedDates(){
         return [...this.#excludedDates.values().map(DateRange.dateFormatted)]
@@ -116,7 +120,6 @@ function DateRangeElement({dateRange}){
         setEditing(false)
         logActivity('dateRange selected/updated')
     },[selectedRange])
-    console.log(dateRange.excludedDates)
     return (
         <div>
             <div className='dateRangeName'>{dateRange.name}</div>
@@ -132,6 +135,19 @@ function DateRangeElement({dateRange}){
                 />
             </> }
             {dateRange.isActive && dateRange.isComplete && <div>
+                {dateRange.hasExclusions && <div>
+                    Excluding
+                    <ul>
+                        {dateRange.excludedDates.map((d,i)=>(
+                            <li key={i}>
+                                {d} <span onClick={()=>{
+                                    logActivity('removed date Exclusion')
+                                    dateRange.removeExcludedDate(d)
+                                }}>&#x2716;</span>
+                            </li>
+                        )) }
+                    </ul>
+                </div>}
                 <small><a onClick={()=>{setEditing(true)}}>
                     Edit date range
                 </a></small>

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -80,8 +80,12 @@ export class DateRange extends Factor {
             let dow = d.getUTCDay()
             let isodow = dow == 0 ? 7 : dow
             if( daysOptions.hasDay(isodow) ){
-                // if holidays are NOT included, check the date isn't a holiday
-                if( ! ( holidaysExcluded && holidayDates.has(formatISODate(d)) ) ){
+                if(
+                    // if dates are excluded check this isn't one of them
+                    !(this.hasExclusions && this.#excludedDates.has(DateRange.dateFormatted(d)))
+                    // if holidays are NOT included, check the date isn't a holiday
+                    && !(holidaysExcluded && holidayDates.has(formatISODate(d)))
+                ){
                     dayCount ++
                 }
             }

--- a/frontend/src/dateRange.js
+++ b/frontend/src/dateRange.js
@@ -110,7 +110,7 @@ function formatISODate(dt){ // this is waaay too complicated... alas
 function DateRangeElement({dateRange}){
     const { logActivity } = useContext(DataContext)
     const [ selectedRange, setSelectedRange ] = useState(undefined)
-    const [ editing, setEditing ] = useState(true)
+    const [ editing, setEditing ] = useState(! dateRange.isComplete)
     const [ addingDateExclusion, setAddingDateExclusion ] = useState(false)
     useEffect(()=>{
         if(!selectedRange) return;
@@ -123,7 +123,6 @@ function DateRangeElement({dateRange}){
     return (
         <div>
             <div className='dateRangeName'>{dateRange.name}</div>
-
             {dateRange.isActive && (editing || ! dateRange.isComplete)&& <>
                 <Calendar
                     value={selectedRange}

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -81,6 +81,10 @@ export class TravelTimeQuery {
     get caveats(){
         // offer some basic warnings where things look especially sketchy
         let warnings = new Set()
+        // mention any date exclusions first
+        if(this.#dateRange.hasExclusions){
+            warnings.add(`excludes the following dates: ${this.#dateRange.excludedDates.join(', ')}`)
+        }
         // check sample size a couple different ways
         const n = this.#results?.observations?.length
         if(n == 0){

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -56,7 +56,7 @@ export class TravelTimeQuery {
             .catch( this.#errorMessage = 'unhandled server error' )
     }
     get hasData(){
-        return Boolean(this.#results.get(this.URI))
+        return this.#results.has(this.URI)
     }
     get isFinished(){
         return this.hasData || Boolean(this.#errorMessage)
@@ -81,6 +81,7 @@ export class TravelTimeQuery {
     }
     get caveats(){
         // offer some basic warnings where things look especially sketchy
+        // and also flag excluded dates
         let warnings = new Set()
         // mention any date exclusions first
         if(this.#dateRange.hasExclusions){

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -6,7 +6,7 @@ export class TravelTimeQuery {
     #dateRange
     #days
     #holidayOption
-    #results
+    #results = new Map()
     #errorMessage
     constructor({corridor,timeRange,dateRange,days,holidayOption}){
         this.#corridor = corridor
@@ -44,18 +44,19 @@ export class TravelTimeQuery {
     async fetchData(){
         if( this.hoursInRange < 1 ){
             // no possible data to fetch
-            return this.#results = undefined
+            this.#results.delete(this.URI)
+            return undefined
         }
         return fetch(this.URI)
             .then( response => response.json() )
             .then( data => {
-                this.#results = data?.results
+                this.#results.set(this.URI, data?.results)
                 this.#errorMessage = data?.error
             } )
             .catch( this.#errorMessage = 'unhandled server error' )
     }
     get hasData(){
-        return Boolean(this.#results)
+        return Boolean(this.#results.get(this.URI))
     }
     get isFinished(){
         return this.hasData || Boolean(this.#errorMessage)
@@ -86,7 +87,7 @@ export class TravelTimeQuery {
             warnings.add(`excludes the following dates: ${this.#dateRange.excludedDates.join(', ')}`)
         }
         // check sample size a couple different ways
-        const n = this.#results?.observations?.length
+        const n = this.#results.get(this.URI)?.observations?.length
         if(n == 0){
             warnings.add('no data available')
         }else if(n <= 10){
@@ -95,11 +96,11 @@ export class TravelTimeQuery {
             warnings.add(`many time periods with missing or insufficient data`)
         }
         // check travel time variability / skew
-        const intervals = this.#results?.estimates?.mean?.confidenceInterval
+        const intervals = this.#results.get(this.URI)?.estimates?.mean?.confidenceInterval
         if(
             (
                 intervals?.upper.seconds - intervals?.lower.seconds
-            ) >= 0.5 * this.#results?.estimates?.mean?.estimate?.seconds
+            ) >= 0.5 * this.#results.get(this.URI)?.estimates?.mean?.estimate?.seconds
         ){
             warnings.add('travel times are highly variable')
         }
@@ -122,15 +123,19 @@ export class TravelTimeQuery {
         )
         record.set('hoursInRange', this.hoursInRange);
         // structure is the same for each of the parameter estimates and their CIs
+        const results = this.#results.get(this.URI);
         ['mean','firstQuartile','median','thirdQuartile'].map( param => {
-            record.set(`time_${param}`, this.#results?.estimates?.[param]?.estimate?.seconds)
+            record.set(
+                `time_${param}`,
+                results?.estimates?.[param]?.estimate?.seconds
+            )
             record.set(
                 `time_${param}_ci_lower`,
-                this.#results?.estimates?.[param]?.confidenceInterval?.lower?.seconds
+                results?.estimates?.[param]?.confidenceInterval?.lower?.seconds
             )
             record.set(
                 `time_${param}_ci_upper`,
-                this.#results?.estimates?.[param]?.confidenceInterval?.upper?.seconds
+                results?.estimates?.[param]?.confidenceInterval?.upper?.seconds
             )
         })
         // print errors if any, else warnings if any

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -27,8 +27,14 @@ export class TravelTimeQuery {
         path += `/${this.#holidayOption.holidaysIncluded}`
         // days of week
         path += `/${this.#days.apiString}`
-        // pass an arg to bypass the cache (development builds only)
-        path += process.env.NODE_ENV === 'development' ? '?noCache' : ''
+        let getArgs = []
+        if(process.env.NODE_ENV === 'development'){ getArgs.push('noCache') }
+        if(this.#dateRange.hasExclusions){
+            getArgs.push(
+                `excludeDates=${this.#dateRange.excludedDates.join(',')}`
+            )
+        }
+        if(getArgs.length > 0){ path += '?' + getArgs.join('&') }
         return path
     }
     get corridor(){ return this.#corridor }


### PR DESCRIPTION
This will allow the app to optionally accept a set of dates to exclude from the aggregations per date range. 

Quite a few little features had to be modified to enable this without creating any reversions on other features:
* daysInRange calculations
* an additional URI GET parameter + query logic
* cache/store retrieved results in a map keyed by URI (to break cache if URI changes)
* new editing controls on the `DateRange` factors
* consideration of these new params in reconstruction from URIs in a file
* add asterisk in `DateRange` name as necessary with corresponding notes in the output