### PR TITLE
Check that queries have time in range before adding to query list

### DIFF
--- a/frontend/src/spatialData.js
+++ b/frontend/src/spatialData.js
@@ -133,6 +133,7 @@ export class SpatialData {
                             ){ // only the no-holidays version of this will be queried
                                 return
                             }
+                            if(ttq.hoursInRange == 0){ return }
                             crossProduct.push(ttq)
                         } )
                     } )


### PR DESCRIPTION
Resolves #261

Before adding a newly constructed travel time query to the list to be queried, this checks that some time is in range for that query.

This means you can set up an impossible combination like the following and it just won't register. In this case the DateRange covers just one weekend but the day of week selection is weekdays only. 

<img width="482" height="611" alt="Screenshot 2026-03-27 at 16-02-53 Travel Time Request App" src="https://github.com/user-attachments/assets/db3a92f8-07a0-4a15-a364-e8482d0c5cbe" />

Toggling on one of the weekend days allows this to be submitted.

This will also fix the problem as discovered in #259 where dates can be excluded. 