### PR TITLE
Match `notes` field warnings to those discussed elsewhere

### DIFF
--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -1,5 +1,7 @@
 import { domain } from './domain.js'
 
+const estimatedParameters = ['mean','firstQuartile','median','thirdQuartile']
+
 export class TravelTimeQuery {
     #corridor
     #timeRange
@@ -84,15 +86,20 @@ export class TravelTimeQuery {
         }else if(n / this.hoursInRange < 0.2){
             warnings.add(`many time periods with missing or insufficient data`)
         }
-        // check travel time variability / skew
-        const intervals = this.#results?.estimates?.mean?.confidenceInterval
-        if(
-            (
-                intervals?.upper.seconds - intervals?.lower.seconds
-            ) >= 0.5 * this.#results?.estimates?.mean?.estimate?.seconds
-        ){
-            warnings.add('travel times are highly variable')
-        }
+        // check range of sampling variability relative to estimated parameter
+        if(n <= 20) return warnings
+        // but only if N is past our threshold
+        estimatedParameters.forEach( param => {
+            const intervals = this.#results?.estimates?.[param]?.confidenceInterval
+            const estimate = this.#results?.estimates?.[param]?.estimate
+            if( // "range relative to travel time" AKA rrttt
+                (
+                    intervals?.upper.seconds - intervals?.lower.seconds
+                ) >= 0.5 * estimate?.seconds
+            ){
+                warnings.add(`${param} travel times may be unreliable`)
+            }
+        } )
         return warnings
     }
     resultsRecord(type='json'){
@@ -112,7 +119,7 @@ export class TravelTimeQuery {
         )
         record.set('hoursInRange', this.hoursInRange);
         // structure is the same for each of the parameter estimates and their CIs
-        ['mean','firstQuartile','median','thirdQuartile'].map( param => {
+        estimatedParameters.map( param => {
             record.set(`time_${param}`, this.#results?.estimates?.[param]?.estimate?.seconds)
             record.set(
                 `time_${param}_ci_lower`,

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -86,17 +86,14 @@ export class TravelTimeQuery {
         }else if(n / this.hoursInRange < 0.2){
             warnings.add(`many time periods with missing or insufficient data`)
         }
-        // check range of sampling variability relative to estimated parameter
+        // check range of sampling variability relative to estimated parameters
         if(n <= 20) return warnings
         // but only if N is past our threshold
         estimatedParameters.forEach( param => {
             const intervals = this.#results?.estimates?.[param]?.confidenceInterval
             const estimate = this.#results?.estimates?.[param]?.estimate
-            if( // "range relative to travel time" AKA rrttt
-                (
-                    intervals?.upper.seconds - intervals?.lower.seconds
-                ) >= 0.5 * estimate?.seconds
-            ){
+            const intervalRange = intervals?.upper.seconds - intervals?.lower.seconds
+            if(intervalRange >= 0.5 * estimate?.seconds){
                 warnings.add(`${param} travel times may be unreliable`)
             }
         } )

--- a/frontend/src/travelTimeQuery.js
+++ b/frontend/src/travelTimeQuery.js
@@ -79,7 +79,7 @@ export class TravelTimeQuery {
         const n = this.#results?.observations?.length
         if(n == 0){
             warnings.add('no data available')
-        }else if(n <= 10){
+        }else if(n <= 20){
             warnings.add(`estimate is based on only ${n} observation(s)`)
         }else if(n / this.hoursInRange < 0.2){
             warnings.add(`many time periods with missing or insufficient data`)


### PR DESCRIPTION
This generalizes the `rrttt` criteria from mean-only to all estimated parameters. 0.5 threshold is pretty lenient and shouldn't often be invoked.